### PR TITLE
Remove advanced login options from AbstraxionSignin

### DIFF
--- a/.changeset/honest-apples-admire.md
+++ b/.changeset/honest-apples-admire.md
@@ -1,0 +1,5 @@
+---
+"@burnt-labs/abstraxion": minor
+---
+
+Remove the advanced login options (Metamask and Keplr) from the AbstraxionSignin component. The showAdvanced state variable and related code have been deleted, simplifying the sign-in process for users.

--- a/packages/abstraxion/src/components/AbstraxionSignin/index.tsx
+++ b/packages/abstraxion/src/components/AbstraxionSignin/index.tsx
@@ -25,7 +25,6 @@ export const AbstraxionSignin = () => {
   const [otp, setOtp] = useState("");
   const [otpError, setOtpError] = useState("");
   const [timeLeft, setTimeLeft] = useState<number | null>(null);
-  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const { setConnectionType } = useContext(
     AbstraxionContext,
@@ -194,37 +193,6 @@ export const AbstraxionSignin = () => {
             >
               Passkey/Biometrics
             </Button>
-            <div
-              className="ui-flex ui-w-full ui-cursor-pointer ui-items-center ui-text-sm ui-text-black dark:ui-text-white"
-              onClick={() => setShowAdvanced(!showAdvanced)}
-            >
-              Advanced <ChevronDown isUp={showAdvanced} />{" "}
-              {showAdvanced ? "Login with an existing EOA" : ""}
-            </div>
-            {showAdvanced && (
-              <div className="ui-flex ui-w-full ui-items-center ui-gap-4">
-                <Button
-                  structure="outlined"
-                  theme="primary"
-                  fullWidth={true}
-                  onClick={() => {
-                    handleConnect(WalletType.METAMASK_SNAP_LEAP);
-                  }}
-                >
-                  Metamask
-                </Button>
-                <Button
-                  structure="outlined"
-                  theme="primary"
-                  fullWidth={true}
-                  onClick={() => {
-                    handleConnect(WalletType.KEPLR);
-                  }}
-                >
-                  Keplr
-                </Button>
-              </div>
-            )}
           </div>
           <p className="ui-text-xs ui-text-zinc-400 dark:ui-text-zinc-600">
             By continuing, you agree to Burnt's{" "}


### PR DESCRIPTION
The changes remove the advanced login options (Metamask and Keplr) from the AbstraxionSignin component. The showAdvanced state variable and related code have been deleted, simplifying the sign-in process for users.

close #19