### PR TITLE
Update wallet create API endpoints and Stytch project tokens

### DIFF
--- a/.changeset/tame-cows-add.md
+++ b/.changeset/tame-cows-add.md
@@ -1,0 +1,7 @@
+---
+"abstraxion-dashboard": minor
+"@burnt-labs/abstraxion": minor
+"@burnt-labs/signers": minor
+---
+
+Change API endpoints to the 'live' infrastructure and the live stytch project id

--- a/apps/abstraxion-dashboard/components/AbstraxionWallets/index.tsx
+++ b/apps/abstraxion-dashboard/components/AbstraxionWallets/index.tsx
@@ -76,7 +76,7 @@ export const AbstraxionWallets = () => {
       }
       setIsGeneratingNewWallet(true);
       const res = await fetch(
-        "https://burnt-abstraxion-api.onrender.com/api/v1/jwt-accounts/create",
+        "https://aa.xion-testnet-1.burnt.com/api/v1/jwt-accounts/create",
         {
           method: "POST",
           headers: {

--- a/packages/abstraxion/src/components/AbstraxionWallets/index.tsx
+++ b/packages/abstraxion/src/components/AbstraxionWallets/index.tsx
@@ -76,7 +76,7 @@ export const AbstraxionWallets = () => {
       }
       setIsGeneratingNewWallet(true);
       const res = await fetch(
-        "https://burnt-abstraxion-api.onrender.com/api/v1/jwt-accounts/create",
+        "https://aa.xion-testnet-1.burnt.com/api/v1/jwt-accounts/create",
         {
           method: "POST",
           headers: {

--- a/packages/abstraxion/src/lib.ts
+++ b/packages/abstraxion/src/lib.ts
@@ -4,7 +4,7 @@ import { StytchHeadlessClient } from "@stytch/vanilla-js/dist/index.headless";
 
 // TODO: Temporarily hard-coded
 export const stytchClient: StytchHeadlessClient = createStytchHeadlessClient(
-  "public-token-test-317adb7b-a52d-4e45-8c2a-d7dab1ef10a0",
+  "public-token-live-87901ec3-ef19-48ca-b3f4-842be750181b",
 );
 
 // TODO: Refactor to be dynamic. Local dev uri must be device IP.

--- a/packages/signers/src/signers/jwt-signer.ts
+++ b/packages/signers/src/signers/jwt-signer.ts
@@ -56,7 +56,7 @@ export class AbstractAccountJWTSigner extends AASigner {
     const message = Buffer.from(hashSignBytes).toString("base64");
 
     const authResponse = await fetch(
-      "https://burnt-abstraxion-api.onrender.com/api/v1/sessions/authenticate",
+      "https://aa.xion-testnet-1.burnt.com/api/v1/sessions/authenticate",
       {
         method: "POST",
         headers: {
@@ -109,7 +109,7 @@ export class AbstractAccountJWTSigner extends AASigner {
     const hashedMessage = Buffer.from(hashSignBytes).toString("base64");
 
     const authResponse = await fetch(
-      "https://burnt-abstraxion-api.onrender.com/api/v1/sessions/authenticate",
+      "https://aa.xion-testnet-1.burnt.com/api/v1/sessions/authenticate",
       {
         method: "POST",
         headers: {

--- a/packages/signers/src/signers/utils/index.ts
+++ b/packages/signers/src/signers/utils/index.ts
@@ -22,7 +22,11 @@ import {
   SingleSmartWalletQuery,
 } from "../../interfaces/queries";
 import { OTPsAuthenticateResponse } from "stytch";
-import { ApolloClient, InMemoryCache, NormalizedCacheObject } from "@apollo/client";
+import {
+  ApolloClient,
+  InMemoryCache,
+  NormalizedCacheObject,
+} from "@apollo/client";
 
 let apolloClientInstance: ApolloClient<NormalizedCacheObject>;
 
@@ -36,7 +40,6 @@ export const getApolloClient = (url?: string) => {
   }
   return apolloClientInstance;
 };
-
 
 export type INodes<T> = {
   nodes: Array<T>;
@@ -86,7 +89,7 @@ export function customAccountFromAny(input: Any): Account {
 export function makeAAuthInfo(
   account: Account,
   pubKey: Uint8Array,
-  fee: StdFee
+  fee: StdFee,
 ): AuthInfo {
   return AuthInfo.fromPartial({
     signerInfos: [
@@ -123,7 +126,7 @@ export function makeAAuthInfo(
 export async function getAAccounts(
   accounts: readonly AccountData[],
   abstractAccount: string,
-  indexerUrl: string
+  indexerUrl: string,
 ): Promise<AAccountData[]> {
   const defaultData: AAccountData = {
     address: "",
@@ -172,7 +175,7 @@ export async function getAAccounts(
             algo: authenticator.type.toLowerCase() as Algo,
             pubkey: new Uint8Array(), // to signify an AA account
             authenticatorId: Number(
-              authenticator.authenticatorId.split("xion")[2]
+              authenticator.authenticatorId.split("xion")[2],
             ),
           });
         }
@@ -189,7 +192,7 @@ export async function getAAccounts(
  */
 export async function getAALastAuthenticatorId(
   abstractAccount: string,
-  indexerUrl: string
+  indexerUrl: string,
 ): Promise<number> {
   const apolloClient = getApolloClient(indexerUrl);
   const { data } = await apolloClient.query<{
@@ -216,16 +219,19 @@ export async function getAALastAuthenticatorId(
 export async function buildAddJWTAuthenticatorMsg(
   abstractAccount: string,
   session: OTPsAuthenticateResponse, // this is the extra data required for the authenticator,
-  indexerUrl: string
+  indexerUrl: string,
 ): Promise<AddAuthenticator | undefined> {
   // get the AA lastAuthenticatorId
-  const lastAuthenticatorId = await getAALastAuthenticatorId(abstractAccount, indexerUrl);
+  const lastAuthenticatorId = await getAALastAuthenticatorId(
+    abstractAccount,
+    indexerUrl,
+  );
   let addAuthMsg: AddAuthenticator = {
     add_auth_method: {
       add_authenticator: {
         Jwt: {
           id: lastAuthenticatorId + 1,
-          aud: "project-test-e97208b8-8b04-4810-a0ad-10932d5a1d12",
+          aud: "project-live-7e4a3221-79cd-4f34-ac1d-fedac4bde13e",
           sub: session.user.user_id,
           token: session.session_token,
         },


### PR DESCRIPTION
Switched to using 'live' API endpoints and project tokens for Stytch and Abstraxion. The updated endpoints are for authenticating sessions and creating JWT accounts. The Stytch project tokens have been updated from 'test' to 'live'. Additionally, the minor formatting changes have been made to improve code readability.