### PR TITLE
Persistence

### DIFF
--- a/.changeset/tasty-masks-kiss.md
+++ b/.changeset/tasty-masks-kiss.md
@@ -2,4 +2,4 @@
 "@burnt-labs/abstraxion": minor
 ---
 
-Add grantee signer client to seamlessly handle grantor/grantee relationships
+Add grantee signer client to seamlessly handle granter/grantee relationships

--- a/.changeset/tough-dolls-count.md
+++ b/.changeset/tough-dolls-count.md
@@ -1,0 +1,5 @@
+---
+"@burnt-labs/abstraxion": minor
+---
+
+persistence and related state cleanup

--- a/packages/abstraxion/CHANGELOG.md
+++ b/packages/abstraxion/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [#41](https://github.com/burnt-labs/xion.js/pull/41) [`a269cdf`](https://github.com/burnt-labs/xion.js/commit/a269cdf88722408e91b643d12ce4181ce26296f3) Thanks [@BurntVal](https://github.com/BurntVal)! - abstraxion dynamic url for grant creation on dashboard
 
-- [#44](https://github.com/burnt-labs/xion.js/pull/44) [`56b9f87`](https://github.com/burnt-labs/xion.js/commit/56b9f87482a7210072eaa279960d1ff01ad5b4e0) Thanks [@justinbarry](https://github.com/justinbarry)! - Add grantee signer client to seamlessly handle grantor/grantee relationships
+- [#44](https://github.com/burnt-labs/xion.js/pull/44) [`56b9f87`](https://github.com/burnt-labs/xion.js/commit/56b9f87482a7210072eaa279960d1ff01ad5b4e0) Thanks [@justinbarry](https://github.com/justinbarry)! - Add grantee signer client to seamlessly handle granter/grantee relationships
 
 ### Patch Changes
 

--- a/packages/abstraxion/src/GranteeSignerClient.ts
+++ b/packages/abstraxion/src/GranteeSignerClient.ts
@@ -14,12 +14,12 @@ import {
 } from "@cosmjs/tendermint-rpc";
 
 interface GranteeSignerOptions {
-  readonly grantorAddress: string;
+  readonly granterAddress: string;
   readonly granteeAddress: string;
 }
 
 export class GranteeSignerClient extends SigningCosmWasmClient {
-  protected readonly grantorAddress: string;
+  protected readonly granterAddress: string;
   protected readonly granteeAddress: string;
 
   public static async connectWithSigner(
@@ -43,16 +43,16 @@ export class GranteeSignerClient extends SigningCosmWasmClient {
     cometClient: TendermintClient | undefined,
     signer: OfflineSigner,
     {
-      grantorAddress,
+      granterAddress,
       granteeAddress,
       ...options
     }: SigningCosmWasmClientOptions & GranteeSignerOptions,
   ) {
     super(cometClient, signer, options);
-    if (grantorAddress === undefined) {
-      throw new Error("grantorAddress is required");
+    if (granterAddress === undefined) {
+      throw new Error("granterAddress is required");
     }
-    this.grantorAddress = grantorAddress;
+    this.granterAddress = granterAddress;
 
     if (granteeAddress === undefined) {
       throw new Error("granteeAddress is required");
@@ -66,8 +66,8 @@ export class GranteeSignerClient extends SigningCosmWasmClient {
     fee: StdFee | "auto" | number,
     memo = "",
   ): Promise<DeliverTxResponse> {
-    // Figure out if the signerAddress is a grantor
-    if (signerAddress === this.grantorAddress) {
+    // Figure out if the signerAddress is a granter
+    if (signerAddress === this.granterAddress) {
       signerAddress = this.granteeAddress;
       // Wrap the signerAddress in a MsgExec
       messages = [
@@ -91,8 +91,8 @@ export class GranteeSignerClient extends SigningCosmWasmClient {
     memo: string,
     explicitSignerData?: SignerData,
   ): Promise<TxRaw> {
-    // Figure out if the signerAddress is a grantor
-    if (signerAddress === this.grantorAddress) {
+    // Figure out if the signerAddress is a granter
+    if (signerAddress === this.granterAddress) {
       signerAddress = this.granteeAddress;
       // Wrap the signerAddress in a MsgExec
       messages = [

--- a/packages/abstraxion/src/components/Abstraxion/index.tsx
+++ b/packages/abstraxion/src/components/Abstraxion/index.tsx
@@ -42,7 +42,7 @@ export function Abstraxion({
         ) : isConnecting ? (
           <Loading />
         ) : isConnected ? (
-          <Connected />
+          <Connected onClose={onClose} />
         ) : (
           <AbstraxionSignin />
         )}

--- a/packages/abstraxion/src/components/AbstraxionContext/index.tsx
+++ b/packages/abstraxion/src/components/AbstraxionContext/index.tsx
@@ -10,8 +10,8 @@ export interface AbstraxionContextProps {
   setAbstraxionError: React.Dispatch<React.SetStateAction<string>>;
   abstraxionAccount: DirectSecp256k1HdWallet | undefined;
   setAbstraxionAccount: React.Dispatch<DirectSecp256k1HdWallet | undefined>;
-  grantorAddress: string;
-  setGrantorAddress: React.Dispatch<React.SetStateAction<string>>;
+  granterAddress: string;
+  setgranterAddress: React.Dispatch<React.SetStateAction<string>>;
   contracts?: string[];
   dashboardUrl?: string;
 }
@@ -35,7 +35,7 @@ export const AbstraxionContextProvider = ({
   const [abstraxionAccount, setAbstraxionAccount] = useState<
     DirectSecp256k1HdWallet | undefined
   >(undefined);
-  const [grantorAddress, setGrantorAddress] = useState("");
+  const [granterAddress, setgranterAddress] = useState("");
 
   return (
     <AbstraxionContext.Provider
@@ -48,8 +48,8 @@ export const AbstraxionContextProvider = ({
         setAbstraxionError,
         abstraxionAccount,
         setAbstraxionAccount,
-        grantorAddress,
-        setGrantorAddress,
+        granterAddress,
+        setgranterAddress,
         contracts,
         dashboardUrl,
       }}

--- a/packages/abstraxion/src/components/AbstraxionSignin/index.tsx
+++ b/packages/abstraxion/src/components/AbstraxionSignin/index.tsx
@@ -47,7 +47,7 @@ export function AbstraxionSignin(): JSX.Element {
     setIsConnecting,
     setIsConnected,
     setAbstraxionAccount,
-    setGrantorAddress,
+    setgranterAddress,
     contracts,
     dashboardUrl,
   } = useContext(AbstraxionContext);
@@ -55,9 +55,9 @@ export function AbstraxionSignin(): JSX.Element {
   const isMounted = useRef(false);
   const [tempAccountAddress, setTempAccountAddress] = useState("");
 
-  function configureGrantor(address: string) {
-    setGrantorAddress(address);
-    localStorage.setItem("xion-authz-grantor-account", address);
+  function configuregranter(address: string) {
+    setgranterAddress(address);
+    localStorage.setItem("xion-authz-granter-account", address);
   }
 
   function openDashboardTab(userAddress: string, contracts?: string[]): void {
@@ -103,7 +103,7 @@ export function AbstraxionSignin(): JSX.Element {
             console.error("More than one granter found. Taking first.");
           }
 
-          configureGrantor(uniqueGranters[0]);
+          configuregranter(uniqueGranters[0]);
           break;
         }
       } catch (error) {

--- a/packages/abstraxion/src/components/Connected/Connected.tsx
+++ b/packages/abstraxion/src/components/Connected/Connected.tsx
@@ -5,14 +5,17 @@ import {
   AbstraxionContextProps,
 } from "../AbstraxionContext";
 
-export function Connected() {
-  const { setIsConnected } = useContext(
-    AbstraxionContext,
-  ) as AbstraxionContextProps;
+export function Connected({ onClose }: { onClose: VoidFunction }) {
+  const { setIsConnected, setAbstraxionAccount, setGrantorAddress } =
+    useContext(AbstraxionContext) as AbstraxionContextProps;
 
   function handleLogout() {
-    localStorage.removeItem("xion-authz-temp-account");
     setIsConnected(false);
+    localStorage.removeItem("xion-authz-temp-account");
+    localStorage.removeItem("xion-authz-grantor-account");
+    setAbstraxionAccount(undefined);
+    setGrantorAddress("");
+    onClose();
   }
 
   return (

--- a/packages/abstraxion/src/components/Connected/Connected.tsx
+++ b/packages/abstraxion/src/components/Connected/Connected.tsx
@@ -6,15 +6,15 @@ import {
 } from "../AbstraxionContext";
 
 export function Connected({ onClose }: { onClose: VoidFunction }) {
-  const { setIsConnected, setAbstraxionAccount, setGrantorAddress } =
+  const { setIsConnected, setAbstraxionAccount, setgranterAddress } =
     useContext(AbstraxionContext) as AbstraxionContextProps;
 
   function handleLogout() {
     setIsConnected(false);
     localStorage.removeItem("xion-authz-temp-account");
-    localStorage.removeItem("xion-authz-grantor-account");
+    localStorage.removeItem("xion-authz-granter-account");
     setAbstraxionAccount(undefined);
-    setGrantorAddress("");
+    setgranterAddress("");
     onClose();
   }
 

--- a/packages/abstraxion/src/hooks/useAbstraxionAccount.ts
+++ b/packages/abstraxion/src/hooks/useAbstraxionAccount.ts
@@ -1,8 +1,9 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import {
   AbstraxionContext,
   AbstraxionContextProps,
 } from "@/src/components/AbstraxionContext";
+import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 
 export interface AbstraxionAccount {
   bech32Address: string;
@@ -14,9 +15,47 @@ export interface useAbstraxionAccountProps {
 }
 
 export const useAbstraxionAccount = (): useAbstraxionAccountProps => {
-  const { isConnected, grantorAddress } = useContext(
-    AbstraxionContext,
-  ) as AbstraxionContextProps;
+  const {
+    isConnected,
+    grantorAddress,
+    abstraxionAccount,
+    isConnecting,
+    setGrantorAddress,
+    setAbstraxionAccount,
+    setIsConnected,
+    setIsConnecting,
+  } = useContext(AbstraxionContext) as AbstraxionContextProps;
+
+  useEffect(() => {
+    async function configureAccount() {
+      setIsConnecting(true);
+      const tempKeypair = localStorage.getItem("xion-authz-temp-account");
+      if (tempKeypair) {
+        const deserializedKeypair = await DirectSecp256k1HdWallet.deserialize(
+          tempKeypair,
+          "abstraxion",
+        );
+        setAbstraxionAccount(deserializedKeypair);
+        const grantorAccount = localStorage.getItem(
+          "xion-authz-grantor-account",
+        );
+        if (grantorAccount) {
+          setGrantorAddress(grantorAccount);
+          setIsConnected(true);
+        }
+      } else {
+        // Wipe grantor even if it exists, clean context
+        localStorage.removeItem("xion-authz-grantor-account");
+        setAbstraxionAccount(undefined);
+        setGrantorAddress("");
+      }
+      setIsConnecting(false);
+    }
+
+    if (!isConnecting && !abstraxionAccount && !grantorAddress) {
+      configureAccount();
+    }
+  }, [isConnected, abstraxionAccount, grantorAddress]);
 
   return {
     data: {

--- a/packages/abstraxion/src/hooks/useAbstraxionAccount.ts
+++ b/packages/abstraxion/src/hooks/useAbstraxionAccount.ts
@@ -17,10 +17,10 @@ export interface useAbstraxionAccountProps {
 export const useAbstraxionAccount = (): useAbstraxionAccountProps => {
   const {
     isConnected,
-    grantorAddress,
+    granterAddress,
     abstraxionAccount,
     isConnecting,
-    setGrantorAddress,
+    setgranterAddress,
     setAbstraxionAccount,
     setIsConnected,
     setIsConnecting,
@@ -36,30 +36,30 @@ export const useAbstraxionAccount = (): useAbstraxionAccountProps => {
           "abstraxion",
         );
         setAbstraxionAccount(deserializedKeypair);
-        const grantorAccount = localStorage.getItem(
-          "xion-authz-grantor-account",
+        const granterAccount = localStorage.getItem(
+          "xion-authz-granter-account",
         );
-        if (grantorAccount) {
-          setGrantorAddress(grantorAccount);
+        if (granterAccount) {
+          setgranterAddress(granterAccount);
           setIsConnected(true);
         }
       } else {
-        // Wipe grantor even if it exists, clean context
-        localStorage.removeItem("xion-authz-grantor-account");
+        // Wipe granter even if it exists, clean context
+        localStorage.removeItem("xion-authz-granter-account");
         setAbstraxionAccount(undefined);
-        setGrantorAddress("");
+        setgranterAddress("");
       }
       setIsConnecting(false);
     }
 
-    if (!isConnecting && !abstraxionAccount && !grantorAddress) {
+    if (!isConnecting && !abstraxionAccount && !granterAddress) {
       configureAccount();
     }
-  }, [isConnected, abstraxionAccount, grantorAddress]);
+  }, [isConnected, abstraxionAccount, granterAddress]);
 
   return {
     data: {
-      bech32Address: grantorAddress,
+      bech32Address: granterAddress,
     },
     isConnected: isConnected,
   };

--- a/packages/abstraxion/src/hooks/useAbstraxionSigningClient.ts
+++ b/packages/abstraxion/src/hooks/useAbstraxionSigningClient.ts
@@ -8,7 +8,7 @@ import {
 import { GranteeSignerClient } from "@/src/GranteeSignerClient.ts";
 
 export const useAbstraxionSigningClient = () => {
-  const { isConnected, abstraxionAccount, grantorAddress } = useContext(
+  const { isConnected, abstraxionAccount, granterAddress } = useContext(
     AbstraxionContext,
   ) as AbstraxionContextProps;
 
@@ -23,8 +23,8 @@ export const useAbstraxionSigningClient = () => {
           throw new Error("No account found.");
         }
 
-        if (!grantorAddress) {
-          throw new Error("No grantor found.");
+        if (!granterAddress) {
+          throw new Error("No granter found.");
         }
         const granteeAddress = await abstraxionAccount
           .getAccounts()
@@ -40,19 +40,20 @@ export const useAbstraxionSigningClient = () => {
           abstraxionAccount,
           {
             gasPrice: GasPrice.fromString("0uxion"),
-            grantorAddress,
+            granterAddress,
             granteeAddress,
           },
         );
 
         setAbstractClient(directClient);
       } catch (error) {
+        console.log("Something went wrong: ", error);
         setAbstractClient(undefined);
       }
     }
 
     getSigner();
-  }, [isConnected, abstraxionAccount, grantorAddress]);
+  }, [isConnected, abstraxionAccount, granterAddress]);
 
   return { client: abstractClient };
 };

--- a/packages/abstraxion/src/hooks/useAbstraxionSigningClient.ts
+++ b/packages/abstraxion/src/hooks/useAbstraxionSigningClient.ts
@@ -22,6 +22,10 @@ export const useAbstraxionSigningClient = () => {
         if (!abstraxionAccount) {
           throw new Error("No account found.");
         }
+
+        if (!grantorAddress) {
+          throw new Error("No grantor found.");
+        }
         const granteeAddress = await abstraxionAccount
           .getAccounts()
           .then((accounts) => {
@@ -43,14 +47,12 @@ export const useAbstraxionSigningClient = () => {
 
         setAbstractClient(directClient);
       } catch (error) {
-        console.log("Something went wrong: ", error);
+        setAbstractClient(undefined);
       }
     }
 
-    if (isConnected && abstraxionAccount) {
-      getSigner();
-    }
-  }, [abstraxionAccount, isConnected]);
+    getSigner();
+  }, [isConnected, abstraxionAccount, grantorAddress]);
 
   return { client: abstractClient };
 };


### PR DESCRIPTION
This PR aims to resolve some UX issues.

1. State Persistence
- Upon hard refresh or any state break, the user would be forced down the sign-in flow as the app state wasn't updated
- Now, useAbstraxionAccount automatically handles this and refreshes account state so users have seamless UX

2. Other UX Behaviors
- Logging out wouldn't close modal, thus immediately forcing user down sign-in flow upon logout
- Now, logout handles all state/context/localStorage cleanup and appropriately closes Abstraxion modal.

- "Connecting..." screen would show a little prematurely, so if something went wrong or the redirected tab got lost, there wasn't a quick and easy way to retry via button click
- Now, connecting screen only shows when there was a grant found during polling. (On fast networks, you don't even really see the connecting screen but I'd argue this is better than the former)