### PR TITLE
Add getAccount method in GranteeSignerClient

### DIFF
--- a/.changeset/forty-rice-type.md
+++ b/.changeset/forty-rice-type.md
@@ -1,0 +1,6 @@
+---
+"@burnt-labs/abstraxion": minor
+"@burnt-labs/signers": minor
+---
+
+Add getAccount method in GranteeSignerClient to parse abstractaccount.v1.AbstractAccount type accounts

--- a/packages/abstraxion/src/GranteeSignerClient.ts
+++ b/packages/abstraxion/src/GranteeSignerClient.ts
@@ -4,7 +4,7 @@ import {
   SigningCosmWasmClientOptions,
 } from "@cosmjs/cosmwasm-stargate";
 import { EncodeObject, OfflineSigner } from "@cosmjs/proto-signing";
-import { SignerData, StdFee } from "@cosmjs/stargate";
+import type { Account, SignerData, StdFee } from "@cosmjs/stargate";
 import type { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
 import { MsgExec } from "cosmjs-types/cosmos/authz/v1beta1/tx";
 import {
@@ -12,6 +12,7 @@ import {
   Tendermint37Client,
   TendermintClient,
 } from "@cosmjs/tendermint-rpc";
+import { customAccountFromAny } from "@burnt-labs/signers";
 
 interface GranteeSignerOptions {
   readonly grantorAddress: string;
@@ -58,6 +59,15 @@ export class GranteeSignerClient extends SigningCosmWasmClient {
       throw new Error("granteeAddress is required");
     }
     this.granteeAddress = granteeAddress;
+  }
+
+  public async getAccount(searchAddress: string): Promise<Account | null> {
+    const account =
+      await this.forceGetQueryClient().auth.account(searchAddress);
+    if (!account) {
+      return null;
+    }
+    return customAccountFromAny(account);
   }
 
   public async signAndBroadcast(

--- a/packages/signers/src/index.ts
+++ b/packages/signers/src/index.ts
@@ -8,3 +8,4 @@ export {
   type AAccountData,
 } from "./interfaces";
 export { AbstractAccountJWTSigner } from "./signers/jwt-signer";
+export { customAccountFromAny } from "./signers/utils";


### PR DESCRIPTION
Imported Account from @cosmjs/stargate and added a new method 'getAccount' in GranteeSignerClient to fetch the account data. This method uses 'customAccountFromAny' from the @burnt-labs/signers package to convert the account data received. The 'customAccountFromAny' has also been exported in signers package index file to make it accessible for usage.

Closes #52