### PR TITLE
Add ability for a DAPP to request a token budget alongside contract exec privileges

### DIFF
--- a/.changeset/weak-ears-suffer.md
+++ b/.changeset/weak-ears-suffer.md
@@ -1,0 +1,7 @@
+---
+"abstraxion-dashboard": minor
+"@burnt-labs/abstraxion": minor
+"demo-app": minor
+---
+
+Add ability for a DAPP to request a token budget alongside contract exec privileges

--- a/apps/abstraxion-dashboard/components/Abstraxion/index.tsx
+++ b/apps/abstraxion-dashboard/components/Abstraxion/index.tsx
@@ -17,6 +17,7 @@ import { ErrorDisplay } from "@/components/ErrorDisplay";
 import { useSearchParams } from "next/navigation";
 import { AbstraxionGrant } from "../AbstraxionGrant";
 import Image from "next/image";
+import { calculateJwkThumbprint } from "jose";
 
 export interface ModalProps {
   onClose: VoidFunction;
@@ -39,7 +40,13 @@ export const Abstraxion = ({ isOpen, onClose }: ModalProps) => {
   } = useAbstraxionAccount();
 
   const contracts = searchParams.get("contracts");
-  const contractsArray = contracts?.split(",") || [];
+  let contractsArray;
+  try {
+    contractsArray = JSON.parse(contracts || "");
+  } catch (e) {
+    // If the contracts are not a valid JSON, we split them by comma. Dapp using old version of the library.
+    contractsArray = contracts?.split(",") || [];
+  }
 
   const grantee = searchParams.get("grantee");
   useEffect(() => {

--- a/apps/abstraxion-dashboard/components/AbstraxionGrant/index.tsx
+++ b/apps/abstraxion-dashboard/components/AbstraxionGrant/index.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { Button, Spinner } from "@burnt-labs/ui";
 import { MsgGrant } from "cosmjs-types/cosmos/authz/v1beta1/tx";
 import {
+  CombinedLimit,
   ContractExecutionAuthorization,
   MaxCallsLimit,
 } from "cosmjs-types/cosmwasm/wasm/v1/authz";
@@ -13,9 +14,10 @@ import { CheckIcon } from "../Icons";
 import { EncodeObject } from "@cosmjs/proto-signing";
 import { redirect, useSearchParams } from "next/navigation";
 import * as Sentry from "@sentry/nextjs";
+import type { ContractGrantDescription } from "@burnt-labs/abstraxion";
 
 interface AbstraxionGrantProps {
-  contracts: string[];
+  contracts: ContractGrantDescription[];
   grantee: string;
 }
 
@@ -56,20 +58,42 @@ export const AbstraxionGrant = ({
     const contractExecutionAuthorizationValue =
       ContractExecutionAuthorization.encode(
         ContractExecutionAuthorization.fromPartial({
-          grants: contracts.map((contractAddress) => ({
-            contract: contractAddress,
-            limit: {
-              typeUrl: "/cosmwasm.wasm.v1.MaxCallsLimit",
-              value: MaxCallsLimit.encode(
-                MaxCallsLimit.fromPartial({
-                  remaining: "255",
-                }),
-              ).finish(),
-            },
-            filter: {
-              typeUrl: "/cosmwasm.wasm.v1.AllowAllMessagesFilter",
-            },
-          })),
+          grants: contracts.map((contractGrantDescription) => {
+            if (typeof contractGrantDescription === "string") {
+              const contract = contractGrantDescription;
+              return {
+                contract,
+                limit: {
+                  typeUrl: "/cosmwasm.wasm.v1.MaxCallsLimit",
+                  value: MaxCallsLimit.encode(
+                    MaxCallsLimit.fromPartial({
+                      remaining: "255",
+                    }),
+                  ).finish(),
+                },
+                filter: {
+                  typeUrl: "/cosmwasm.wasm.v1.AllowAllMessagesFilter",
+                },
+              };
+            }
+
+            const { address, amounts } = contractGrantDescription;
+            return {
+              contract: address,
+              limit: {
+                typeUrl: "/cosmwasm.wasm.v1.CombinedLimit",
+                value: CombinedLimit.encode(
+                  CombinedLimit.fromPartial({
+                    callsRemaining: "255",
+                    amounts,
+                  }),
+                ).finish(),
+              },
+              filter: {
+                typeUrl: "/cosmwasm.wasm.v1.AllowAllMessagesFilter",
+              },
+            };
+          }),
         }),
       ).finish();
     const grantValue = MsgGrant.fromPartial({

--- a/apps/demo-app/src/app/layout.tsx
+++ b/apps/demo-app/src/app/layout.tsx
@@ -20,7 +20,14 @@ export default function RootLayout({
       <body className={inter.className}>
         <AbstraxionProvider
           config={{
-            contracts: [seatContractAddress],
+            contracts: [
+              // Usually, you would have a list of different contracts here
+              seatContractAddress,
+              {
+                address: seatContractAddress,
+                amounts: [{ denom: "uxion", amount: "1000000" }],
+              },
+            ],
           }}
         >
           {children}

--- a/packages/abstraxion/src/components/Abstraxion/index.tsx
+++ b/packages/abstraxion/src/components/Abstraxion/index.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogContent } from "@burnt-labs/ui";
 import {
   AbstraxionContext,
   AbstraxionContextProvider,
+  ContractGrantDescription,
 } from "../AbstraxionContext";
 import { Loading } from "../Loading";
 import { ErrorDisplay } from "../ErrorDisplay";
@@ -58,7 +59,7 @@ export function Abstraxion({ onClose }: ModalProps): JSX.Element | null {
 }
 
 export interface AbstraxionConfig {
-  contracts?: string[];
+  contracts?: ContractGrantDescription[];
   dashboardUrl?: string;
 }
 

--- a/packages/abstraxion/src/components/AbstraxionContext/index.tsx
+++ b/packages/abstraxion/src/components/AbstraxionContext/index.tsx
@@ -2,6 +2,13 @@ import type { ReactNode } from "react";
 import { useEffect, createContext, useState } from "react";
 import type { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 
+export type ContractGrantDescription =
+  | string
+  | {
+      address: string;
+      amounts: { denom: string; amount: string }[];
+    };
+
 export interface AbstraxionContextProps {
   isConnected: boolean;
   setIsConnected: React.Dispatch<React.SetStateAction<boolean>>;
@@ -15,7 +22,7 @@ export interface AbstraxionContextProps {
   showModal: boolean;
   setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
   setGranterAddress: React.Dispatch<React.SetStateAction<string>>;
-  contracts?: string[];
+  contracts?: ContractGrantDescription[];
   dashboardUrl?: string;
 }
 
@@ -29,7 +36,7 @@ export function AbstraxionContextProvider({
   dashboardUrl = "https://dashboard.burnt.com",
 }: {
   children: ReactNode;
-  contracts?: string[];
+  contracts?: ContractGrantDescription[];
   dashboardUrl?: string;
 }): JSX.Element {
   const [abstraxionError, setAbstraxionError] = useState("");

--- a/packages/abstraxion/src/components/AbstraxionSignin/index.tsx
+++ b/packages/abstraxion/src/components/AbstraxionSignin/index.tsx
@@ -3,7 +3,10 @@ import { useContext, useEffect, useRef, useState } from "react";
 import { Button, ModalSection, BrowserIcon } from "@burnt-labs/ui";
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { wait } from "@/utils/wait";
-import { AbstraxionContext } from "../AbstraxionContext";
+import {
+  AbstraxionContext,
+  ContractGrantDescription,
+} from "../AbstraxionContext";
 
 interface GrantsResponse {
   grants: Grant[];
@@ -64,13 +67,13 @@ export function AbstraxionSignin(): JSX.Element {
 
   function openDashboardTab(
     userAddress: string,
-    grantContracts?: string[],
+    grantContracts?: ContractGrantDescription[],
   ): void {
     const currentUrl = window.location.href;
     const urlParams = new URLSearchParams();
     urlParams.set("grantee", userAddress);
     // @ts-expect-error - url encoding array
-    urlParams.set("contracts", grantContracts);
+    urlParams.set("contracts", JSON.stringify(grantContracts));
     urlParams.set("redirect_uri", currentUrl);
     const queryString = urlParams.toString(); // Convert URLSearchParams to string
     window.location.href = `${dashboardUrl}?${queryString}`;

--- a/packages/abstraxion/src/index.ts
+++ b/packages/abstraxion/src/index.ts
@@ -6,3 +6,5 @@ export {
   useAbstraxionSigningClient,
   useModal,
 } from "./hooks";
+
+export { ContractGrantDescription } from "./components/AbstraxionContext";


### PR DESCRIPTION
```typescript
 <AbstraxionProvider
          config={{
            contracts: [
              "CONTRACT_ADDRESS",
              {
                address: "CONTRACT_ADDRESS_WHICH_NEEDS_TO_MOVE_FUNDS",
                amounts: [{ denom: "uxion", amount: "1000000" }],
              },
            ],
          }}
        >
          {children}
        </AbstraxionProvider>
```

Will update dashboard design to showcase this information here: #84