### PR TITLE
Add staking/BankSend  grant capability to Abstraxion components

### DIFF
--- a/.changeset/spotty-cats-wink.md
+++ b/.changeset/spotty-cats-wink.md
@@ -1,0 +1,40 @@
+---
+"abstraxion-dashboard": minor
+"@burnt-labs/abstraxion": minor
+"demo-app": minor
+---
+
+Staking Grants
+===
+Add the ability for dapps to request staking grants be give via the dashboard. To request a grant, the dapp will need to set the `stake` prop to `true` in the config of the `abstraxion` provider.
+
+```jsx
+<AbstraxionProvider
+  config={{
+    stake: true,
+  }}
+>
+  {children}
+</AbstraxionProvider>
+```
+
+This will grant `StakeAuthorization` to delegate, undelegate, redelegate and a GenericAuthorization to exec a MsgWithdrawDelegatorReward msg along with a feegrant for these message to cover the fees.
+
+Bank Send Grants
+===
+Add the ability for dapps to request bank send grants be give via the dashboard. To request a grant, the dapp will need to set pass the requested `denom` and `amount` to the config of the `abstraxion` provider.
+
+```jsx
+<AbstraxionProvider
+  config={{
+      bank: [
+          {
+              denom: "uxion",
+              amount: "1000000",
+          },
+      ],
+  }}
+>
+  {children}
+</AbstraxionProvider>
+```

--- a/apps/abstraxion-dashboard/app/page.tsx
+++ b/apps/abstraxion-dashboard/app/page.tsx
@@ -21,11 +21,13 @@ export default function Home() {
   const accountBalance = useAccountBalance(account, client);
 
   const contracts = searchParams.get("contracts");
+  const stake = Boolean(searchParams.get("stake"));
+  const bank = searchParams.get("bank");
   const grantee = searchParams.get("grantee");
 
   return (
     <>
-      {!account?.id || (contracts && grantee) ? (
+      {!account?.id || (grantee && (contracts || stake || bank)) ? (
         <div className="ui-flex ui-h-screen ui-flex-1 ui-items-center ui-justify-center ui-overflow-y-auto ui-p-6">
           <Abstraxion onClose={() => null} isOpen={true} />
         </div>

--- a/apps/abstraxion-dashboard/components/Abstraxion/index.tsx
+++ b/apps/abstraxion-dashboard/components/Abstraxion/index.tsx
@@ -34,6 +34,17 @@ export const Abstraxion = ({ isOpen, onClose }: ModalProps) => {
   const { isConnected, data: account } = useAbstraxionAccount();
 
   const contracts = searchParams.get("contracts");
+  const stake = Boolean(searchParams.get("stake"));
+  const bank = searchParams.get("bank");
+
+  let bankArray;
+  try {
+    bankArray = JSON.parse(bank || "");
+  } catch (e) {
+    // If the bank is not a valid JSON, we split it by comma. Dapp using old version of the library.
+    bankArray = [];
+  }
+
   let contractsArray;
   try {
     contractsArray = JSON.parse(contracts || "");
@@ -59,8 +70,16 @@ export const Abstraxion = ({ isOpen, onClose }: ModalProps) => {
         <DialogContent>
           {abstraxionError ? (
             <ErrorDisplay message={abstraxionError} onClose={onClose} />
-          ) : account?.id && contracts && grantee ? (
-            <AbstraxionGrant contracts={contractsArray} grantee={grantee} />
+          ) : account?.id &&
+            grantee &&
+            // We support granting any combunation of
+            (contractsArray.length > 0 || stake || bankArray.length > 0) ? (
+            <AbstraxionGrant
+              bank={bankArray}
+              contracts={contractsArray}
+              grantee={grantee}
+              stake={stake}
+            />
           ) : isConnected ? (
             <AbstraxionWallets />
           ) : (

--- a/apps/abstraxion-dashboard/components/AbstraxionGrant/generateBankGrant.tsx
+++ b/apps/abstraxion-dashboard/components/AbstraxionGrant/generateBankGrant.tsx
@@ -1,0 +1,30 @@
+import { MsgGrant } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import { SendAuthorization } from "cosmjs-types/cosmos/bank/v1beta1/authz";
+
+export const generateBankGrant = (
+  expiration: bigint,
+  grantee: string,
+  granter: string,
+  bank: { denom: string; amount: string }[],
+) => {
+  return {
+    typeUrl: MsgGrant.typeUrl,
+    value: MsgGrant.fromPartial({
+      grant: {
+        authorization: {
+          typeUrl: SendAuthorization.typeUrl,
+          value: SendAuthorization.encode(
+            SendAuthorization.fromPartial({
+              spendLimit: bank,
+            }),
+          ).finish(),
+        },
+        expiration: {
+          seconds: expiration,
+        },
+      },
+      grantee,
+      granter,
+    }),
+  };
+};

--- a/apps/abstraxion-dashboard/components/AbstraxionGrant/generateContractGrant.tsx
+++ b/apps/abstraxion-dashboard/components/AbstraxionGrant/generateContractGrant.tsx
@@ -1,0 +1,75 @@
+import type { ContractGrantDescription } from "@burnt-labs/abstraxion";
+import {
+  AllowAllMessagesFilter,
+  CombinedLimit,
+  ContractExecutionAuthorization,
+  MaxCallsLimit,
+} from "cosmjs-types/cosmwasm/wasm/v1/authz";
+import { MsgGrant } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+
+export const generateContractGrant = (
+  expiration: bigint,
+  grantee: string,
+  granter: string,
+  contracts: ContractGrantDescription[],
+) => {
+  const contractExecutionAuthorizationValue =
+    ContractExecutionAuthorization.encode(
+      ContractExecutionAuthorization.fromPartial({
+        grants: contracts.map((contractGrantDescription) => {
+          if (typeof contractGrantDescription === "string") {
+            const contract = contractGrantDescription;
+            return {
+              contract,
+              limit: {
+                typeUrl: MaxCallsLimit.typeUrl,
+                value: MaxCallsLimit.encode(
+                  MaxCallsLimit.fromPartial({
+                    remaining: BigInt("255"),
+                  }),
+                ).finish(),
+              },
+              filter: {
+                typeUrl: AllowAllMessagesFilter.typeUrl,
+              },
+            };
+          }
+
+          const { address, amounts } = contractGrantDescription;
+          return {
+            contract: address,
+            limit: {
+              typeUrl: "/cosmwasm.wasm.v1.CombinedLimit",
+              value: CombinedLimit.encode(
+                CombinedLimit.fromPartial({
+                  callsRemaining: BigInt("255"),
+                  amounts,
+                }),
+              ).finish(),
+            },
+            filter: {
+              typeUrl: AllowAllMessagesFilter.typeUrl,
+            },
+          };
+        }),
+      }),
+    ).finish();
+  const grantValue = MsgGrant.fromPartial({
+    grant: {
+      authorization: {
+        typeUrl: ContractExecutionAuthorization.typeUrl,
+        value: contractExecutionAuthorizationValue,
+      },
+      expiration: {
+        seconds: expiration,
+      },
+    },
+    grantee,
+    granter,
+  });
+
+  return {
+    typeUrl: MsgGrant.typeUrl,
+    value: grantValue,
+  };
+};

--- a/apps/abstraxion-dashboard/components/AbstraxionGrant/generateStakeGrant.tsx
+++ b/apps/abstraxion-dashboard/components/AbstraxionGrant/generateStakeGrant.tsx
@@ -1,0 +1,100 @@
+import { MsgGrant } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import { GenericAuthorization } from "cosmjs-types/cosmos/authz/v1beta1/authz";
+import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
+import {
+  AuthorizationType,
+  StakeAuthorization,
+} from "cosmjs-types/cosmos/staking/v1beta1/authz";
+import {
+  AllowedMsgAllowance,
+  BasicAllowance,
+} from "cosmjs-types/cosmos/feegrant/v1beta1/feegrant";
+import { MsgGrantAllowance } from "cosmjs-types/cosmos/feegrant/v1beta1/tx";
+
+export const generateStakeGrant = (
+  expiration: bigint,
+  grantee: string,
+  granter: string,
+): Array<{
+  typeUrl: string;
+  value: MsgGrant | MsgGrantAllowance;
+}> => {
+  const feeGrant = {
+    typeUrl: MsgGrantAllowance.typeUrl,
+    value: MsgGrantAllowance.fromPartial({
+      allowance: {
+        typeUrl: AllowedMsgAllowance.typeUrl,
+        value: AllowedMsgAllowance.encode(
+          AllowedMsgAllowance.fromPartial({
+            allowance: {
+              typeUrl: BasicAllowance.typeUrl,
+              value: BasicAllowance.encode(
+                BasicAllowance.fromPartial({
+                  spendLimit: [],
+                  expiration: {
+                    seconds: expiration,
+                  },
+                }),
+              ).finish(),
+            },
+            allowedMessages: [
+              StakeAuthorization.typeUrl,
+              MsgWithdrawDelegatorReward.typeUrl,
+            ],
+          }),
+        ).finish(),
+      },
+      grantee,
+      granter,
+    }),
+  };
+
+  // Need to grant MsgWithdrawDelegatorReward
+  const genericMsgGrant = {
+    typeUrl: MsgGrant.typeUrl,
+    value: MsgGrant.fromPartial({
+      grant: {
+        authorization: {
+          typeUrl: GenericAuthorization.typeUrl,
+          value: GenericAuthorization.encode(
+            GenericAuthorization.fromPartial({
+              msg: MsgWithdrawDelegatorReward.typeUrl,
+            }),
+          ).finish(),
+        },
+        expiration: {
+          seconds: expiration,
+        },
+      },
+      grantee,
+      granter,
+    }),
+  };
+
+  const grants = [
+    AuthorizationType.AUTHORIZATION_TYPE_DELEGATE,
+    AuthorizationType.AUTHORIZATION_TYPE_UNDELEGATE,
+    AuthorizationType.AUTHORIZATION_TYPE_REDELEGATE,
+  ].map((authorizationType) => ({
+    typeUrl: MsgGrant.typeUrl,
+    value: MsgGrant.fromPartial({
+      grant: {
+        authorization: {
+          typeUrl: StakeAuthorization.typeUrl,
+          value: StakeAuthorization.encode(
+            StakeAuthorization.fromPartial({
+              authorizationType,
+            }),
+          ).finish(),
+        },
+        expiration: {
+          seconds: expiration,
+        },
+      },
+      grantee,
+      granter,
+    }),
+  }));
+
+  return [...grants, genericMsgGrant, feeGrant];
+};

--- a/apps/demo-app/src/app/layout.tsx
+++ b/apps/demo-app/src/app/layout.tsx
@@ -28,6 +28,13 @@ export default function RootLayout({
                 amounts: [{ denom: "uxion", amount: "1000000" }],
               },
             ],
+            stake: true,
+            bank: [
+              {
+                denom: "uxion",
+                amount: "1000000",
+              },
+            ],
           }}
         >
           {children}

--- a/packages/abstraxion/src/components/Abstraxion/index.tsx
+++ b/packages/abstraxion/src/components/Abstraxion/index.tsx
@@ -5,6 +5,7 @@ import {
   AbstraxionContext,
   AbstraxionContextProvider,
   ContractGrantDescription,
+  SpendLimit,
 } from "../AbstraxionContext";
 import { Loading } from "../Loading";
 import { ErrorDisplay } from "../ErrorDisplay";
@@ -63,6 +64,8 @@ export interface AbstraxionConfig {
   dashboardUrl?: string;
   rpcUrl?: string;
   restUrl?: string;
+  stake?: boolean;
+  bank?: SpendLimit[];
 }
 
 export function AbstraxionProvider({
@@ -78,6 +81,8 @@ export function AbstraxionProvider({
       dashboardUrl={config.dashboardUrl}
       rpcUrl={config.rpcUrl}
       restUrl={config.restUrl}
+      stake={config.stake}
+      bank={config.bank}
     >
       {children}
     </AbstraxionContextProvider>

--- a/packages/abstraxion/src/components/AbstraxionContext/index.tsx
+++ b/packages/abstraxion/src/components/AbstraxionContext/index.tsx
@@ -1,13 +1,15 @@
 import type { ReactNode } from "react";
-import { useEffect, createContext, useState } from "react";
+import { createContext, useEffect, useState } from "react";
 import type { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { testnetChainInfo } from "@burnt-labs/constants";
+
+export type SpendLimit = { denom: string; amount: string };
 
 export type ContractGrantDescription =
   | string
   | {
       address: string;
-      amounts: { denom: string; amount: string }[];
+      amounts: SpendLimit[];
     };
 
 export interface AbstraxionContextProps {
@@ -27,6 +29,8 @@ export interface AbstraxionContextProps {
   dashboardUrl?: string;
   rpcUrl?: string;
   restUrl?: string;
+  stake?: boolean;
+  bank?: SpendLimit[];
 }
 
 export const AbstraxionContext = createContext<AbstraxionContextProps>(
@@ -39,12 +43,16 @@ export function AbstraxionContextProvider({
   dashboardUrl = "https://dashboard.burnt.com",
   rpcUrl = testnetChainInfo.rpc,
   restUrl = testnetChainInfo.rest,
+  stake = false,
+  bank,
 }: {
   children: ReactNode;
   contracts?: ContractGrantDescription[];
   dashboardUrl?: string;
   rpcUrl?: string;
   restUrl?: string;
+  stake?: boolean;
+  bank?: SpendLimit[];
 }): JSX.Element {
   const [abstraxionError, setAbstraxionError] = useState("");
   const [isConnected, setIsConnected] = useState(false);
@@ -81,6 +89,8 @@ export function AbstraxionContextProvider({
         dashboardUrl,
         rpcUrl,
         restUrl,
+        stake,
+        bank,
       }}
     >
       {children}

--- a/packages/abstraxion/src/components/AbstraxionSignin/index.tsx
+++ b/packages/abstraxion/src/components/AbstraxionSignin/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useContext, useEffect, useRef, useState } from "react";
-import { Button, ModalSection, BrowserIcon } from "@burnt-labs/ui";
+import { BrowserIcon, Button, ModalSection } from "@burnt-labs/ui";
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { wait } from "@/utils/wait";
 import {
@@ -50,12 +50,13 @@ export function AbstraxionSignin(): JSX.Element {
     setIsConnecting,
     setIsConnected,
     setAbstraxionAccount,
-    abstraxionAccount,
     setGranterAddress,
     granterAddress,
     contracts,
     dashboardUrl,
     restUrl,
+    stake,
+    bank,
   } = useContext(AbstraxionContext);
 
   const isMounted = useRef(false);
@@ -72,9 +73,18 @@ export function AbstraxionSignin(): JSX.Element {
   ): void {
     const currentUrl = window.location.href;
     const urlParams = new URLSearchParams();
+
+    if (bank) {
+      urlParams.set("bank", JSON.stringify(bank));
+    }
+
+    if (stake) {
+      urlParams.set("stake", "true");
+    }
     urlParams.set("grantee", userAddress);
-    // @ts-expect-error - url encoding array
-    urlParams.set("contracts", JSON.stringify(grantContracts));
+    if (grantContracts) {
+      urlParams.set("contracts", JSON.stringify(grantContracts));
+    }
     urlParams.set("redirect_uri", currentUrl);
     const queryString = urlParams.toString(); // Convert URLSearchParams to string
     window.location.href = `${dashboardUrl}?${queryString}`;


### PR DESCRIPTION
Added a "stake" boolean configuration option to the Abstraxion, AbstraxionContext and AbstraxionSignin components. When set to true, stake-related authorization grants are generated in addition to contract grants in the AbstraxionGrant component. This allows users to stake assets using the Abstraxion interface.

Added a "bank" object to be passed to the dashboard which describes which bank send allowances the dapp will need. 

See [this](https://explorer.burnt.com/xion-testnet-1/tx/ECD68D7123C83E621AF84A646A5371F02E5EADEBD6A1B2AA7ADC822A13642E5D) tx to see the grants bestowed.