### PR TITLE
Allow extra messages in the fee grant

### DIFF
--- a/.changeset/shy-planets-watch.md
+++ b/.changeset/shy-planets-watch.md
@@ -1,0 +1,5 @@
+---
+"abstraxion-dashboard": minor
+---
+
+Allow extra messages in the fee grant

--- a/apps/abstraxion-dashboard/components/AbstraxionGrant/generateStakeGrant.tsx
+++ b/apps/abstraxion-dashboard/components/AbstraxionGrant/generateStakeGrant.tsx
@@ -1,10 +1,14 @@
-import { MsgGrant } from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import { MsgGrant, MsgExec } from "cosmjs-types/cosmos/authz/v1beta1/tx";
 import { GenericAuthorization } from "cosmjs-types/cosmos/authz/v1beta1/authz";
 import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
 import {
   AuthorizationType,
   StakeAuthorization,
 } from "cosmjs-types/cosmos/staking/v1beta1/authz";
+import {
+  MsgDelegate,
+  MsgUndelegate,
+} from "cosmjs-types/cosmos/staking/v1beta1/tx";
 import {
   AllowedMsgAllowance,
   BasicAllowance,
@@ -38,8 +42,10 @@ export const generateStakeGrant = (
               ).finish(),
             },
             allowedMessages: [
-              StakeAuthorization.typeUrl,
               MsgWithdrawDelegatorReward.typeUrl,
+              MsgDelegate.typeUrl,
+              MsgUndelegate.typeUrl,
+              MsgExec.typeUrl,
             ],
           }),
         ).finish(),


### PR DESCRIPTION
After these changes the grantee account is able to perform staking, the fee of the messages is paid by the granter account. Not covering the redelegate flow yet which I am planning to investigate in a later day (I believe it will be `BeginRedelegate.typeUrl`).