### PR TITLE
Add error handling for unavailable Keplr

### DIFF
--- a/.changeset/dirty-years-love.md
+++ b/.changeset/dirty-years-love.md
@@ -1,0 +1,5 @@
+---
+"abstraxion-dashboard": minor
+---
+
+Fix window.keplr error on startup when keplr is not installed

--- a/apps/abstraxion-dashboard/components/AbstraxionWallets/index.tsx
+++ b/apps/abstraxion-dashboard/components/AbstraxionWallets/index.tsx
@@ -1,10 +1,10 @@
 import { useContext, useEffect, useState } from "react";
 import {
-  WalletType,
   getKeplr,
   useAccount,
   useDisconnect,
   useSuggestChainAndConnect,
+  WalletType,
 } from "graz";
 import { useStytch, useStytchUser } from "@stytch/nextjs";
 import { useQuery } from "@apollo/client";
@@ -37,7 +37,12 @@ export const AbstraxionWallets = () => {
   const session_jwt = stytchClient.session.getTokens()?.session_jwt;
   const session_token = stytchClient.session.getTokens()?.session_token;
 
-  const keplr = getKeplr();
+  let keplr;
+  try {
+    keplr = getKeplr();
+  } catch (e) {
+    console.log("Keplr not found");
+  }
   const { data: grazAccount } = useAccount();
   const { client } = useAbstraxionSigningClient();
 

--- a/apps/abstraxion-dashboard/hooks/useAbstraxionSigningClient.ts
+++ b/apps/abstraxion-dashboard/hooks/useAbstraxionSigningClient.ts
@@ -24,7 +24,12 @@ export const useAbstraxionSigningClient = () => {
   const sessionToken = stytch.session.getTokens()?.session_token;
 
   const { data } = useOfflineSigners();
-  const keplr = getKeplr();
+  let keplr;
+  try {
+    keplr = getKeplr();
+  } catch (e) {
+    console.log("Keplr not found");
+  }
 
   const [abstractClient, setAbstractClient] = useState<AAClient | undefined>(
     undefined,
@@ -47,7 +52,7 @@ export const useAbstraxionSigningClient = () => {
           );
           break;
         case "graz":
-          if (data && data.offlineSigner) {
+          if (data && data.offlineSigner && keplr) {
             signer = new AADirectSigner(
               data?.offlineSigner as any, // Temp solution. graz vs internal cosmjs version mismatch
               abstractAccount.id,


### PR DESCRIPTION
An exception handling has been included to manage the unavailability of Keplr in useAbstraxionSigningClient.ts and AbstraxionWallets/index.tsx. An additional condition is added in the process of creating an AADirectSigner to check the presence of Keplr.