### PR TITLE
Add logout function to useAbstraxionSigningClient hook

### DIFF
--- a/.changeset/wicked-colts-reflect.md
+++ b/.changeset/wicked-colts-reflect.md
@@ -1,0 +1,10 @@
+---
+"@burnt-labs/abstraxion": minor
+"demo-app": minor
+---
+
+Add a logout hook method to the `useAbstraxionSigningClient` hook.
+
+```typescript
+  const { client, signArb, logout } = useAbstraxionSigningClient();
+```

--- a/apps/demo-app/src/app/page.tsx
+++ b/apps/demo-app/src/app/page.tsx
@@ -18,7 +18,7 @@ type ExecuteResultOrUndefined = ExecuteResult | undefined;
 export default function Page(): JSX.Element {
   // Abstraxion hooks
   const { data: account } = useAbstraxionAccount();
-  const { client, signArb } = useAbstraxionSigningClient();
+  const { client, signArb, logout } = useAbstraxionSigningClient();
 
   // General state hooks
   const [, setShowModal]: [
@@ -116,6 +116,18 @@ export default function Page(): JSX.Element {
           >
             {loading ? "LOADING..." : "CLAIM SEAT"}
           </Button>
+          {logout ? (
+            <Button
+              disabled={loading}
+              fullWidth
+              onClick={() => {
+                logout();
+              }}
+              structure="base"
+            >
+              {"LOGOUT"}
+            </Button>
+          ) : null}
           {signArb ? (
             <div className="mt-10 w-full">
               <h1 className="text-lg font-normal tracking-tighter text-white">

--- a/packages/abstraxion/src/components/AbstraxionContext/index.tsx
+++ b/packages/abstraxion/src/components/AbstraxionContext/index.tsx
@@ -31,6 +31,7 @@ export interface AbstraxionContextProps {
   restUrl?: string;
   stake?: boolean;
   bank?: SpendLimit[];
+  logout?: () => void;
 }
 
 export const AbstraxionContext = createContext<AbstraxionContextProps>(
@@ -70,6 +71,14 @@ export function AbstraxionContextProvider({
     }
   }, []);
 
+  const logout = () => {
+    setIsConnected(false);
+    localStorage.removeItem("xion-authz-temp-account");
+    localStorage.removeItem("xion-authz-granter-account");
+    setAbstraxionAccount(undefined);
+    setGranterAddress("");
+  };
+
   return (
     <AbstraxionContext.Provider
       value={{
@@ -91,6 +100,7 @@ export function AbstraxionContextProvider({
         restUrl,
         stake,
         bank,
+        logout,
       }}
     >
       {children}

--- a/packages/abstraxion/src/components/Connected/Connected.tsx
+++ b/packages/abstraxion/src/components/Connected/Connected.tsx
@@ -3,15 +3,13 @@ import { Button, ModalSection } from "@burnt-labs/ui";
 import { AbstraxionContext } from "../AbstraxionContext";
 
 export function Connected({ onClose }: { onClose: VoidFunction }): JSX.Element {
-  const { setIsConnected, setAbstraxionAccount, setGranterAddress } =
+  const { setIsConnected, setAbstraxionAccount, setGranterAddress, logout } =
     useContext(AbstraxionContext);
 
   function handleLogout(): void {
-    setIsConnected(false);
-    localStorage.removeItem("xion-authz-temp-account");
-    localStorage.removeItem("xion-authz-granter-account");
-    setAbstraxionAccount(undefined);
-    setGranterAddress("");
+    if (logout) {
+      logout();
+    }
     onClose();
   }
 

--- a/packages/abstraxion/src/hooks/useAbstraxionSigningClient.ts
+++ b/packages/abstraxion/src/hooks/useAbstraxionSigningClient.ts
@@ -10,8 +10,9 @@ export const useAbstraxionSigningClient = (): {
   readonly signArb:
     | ((signerAddress: string, message: string | Uint8Array) => Promise<string>)
     | undefined;
+  readonly logout: (() => void) | undefined;
 } => {
-  const { isConnected, abstraxionAccount, granterAddress, rpcUrl } =
+  const { isConnected, abstraxionAccount, granterAddress, rpcUrl, logout } =
     useContext(AbstraxionContext);
   const [signArbWallet, setSignArbWallet] = useState<
     SignArbSecp256k1HdWallet | undefined
@@ -77,5 +78,9 @@ export const useAbstraxionSigningClient = (): {
     getSigner();
   }, [isConnected, abstraxionAccount, granterAddress]);
 
-  return { client: abstractClient, signArb: signArbWallet?.signArb } as const;
+  return {
+    client: abstractClient,
+    signArb: signArbWallet?.signArb,
+    logout,
+  } as const;
 };


### PR DESCRIPTION
The changeset includes the addition of a logout method to the useAbstraxionSigningClient hook. This function clears the local storage and resets the AbstraxionAccount and granterAddress states. The logout functionality is also integrated into the demo app and reflected in the related tsx files.