### PR TITLE
Add `getGranteeAccountData` method to GranteeSignerClient

### DIFF
--- a/.changeset/strong-eels-peel.md
+++ b/.changeset/strong-eels-peel.md
@@ -1,0 +1,5 @@
+---
+"@burnt-labs/abstraxion-core": minor
+---
+
+Add `getGranteeAccountData` method to the GranteeSignerClient class


### PR DESCRIPTION
A new method called `getGranteeAccountData` has been introduced to the GranteeSignerClient class. This method gets account data for a specific grantee by comparing account addresses. Documented in `.changeset/strong-eels-peel.md` and implemented in `GranteeSignerClient.ts`.