### PR TITLE
Added net type visual elements to dashboard

### DIFF
--- a/.changeset/wild-chicken-bathe.md
+++ b/.changeset/wild-chicken-bathe.md
@@ -1,0 +1,6 @@
+---
+"abstraxion-dashboard": minor
+"demo-app": minor
+---
+
+Added visual elements to dashboard to distinguish between net type.

--- a/apps/abstraxion-dashboard/.env.example
+++ b/apps/abstraxion-dashboard/.env.example
@@ -1,5 +1,5 @@
 # DEFAULTS
-NEXT_PUBLIC_DEPLOYMENT_ENV="mainnnet"
+NEXT_PUBLIC_DEPLOYMENT_ENV="mainnet"
 NEXT_PUBLIC_DEFAULT_API_URL="https://aa.xion-testnet-1.burnt.com"
 NEXT_PUBLIC_DEFAULT_INDEXER_URL="https://api.subquery.network/sq/burnt-labs/xion-indexer"
 NEXT_PUBLIC_DEFAULT_STYTCH_PUBLIC_TOKEN="public-token-live-87901ec3-ef19-48ca-b3f4-842be750181b"

--- a/apps/abstraxion-dashboard/components/Sidebar.tsx
+++ b/apps/abstraxion-dashboard/components/Sidebar.tsx
@@ -3,28 +3,46 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Image from "next/image";
+import { useContext } from "react";
+import { AbstraxionContext, AbstraxionContextProps } from "./AbstraxionContext";
 
-const NAV_OPTIONS = [
-  { text: "home", path: "/" },
-  // { text: "history", path: "/history" },
-  // TODO: Implement Settings Page
-  // { text: "settings", path: "/settings" },
-];
+const NAV_OPTIONS = [{ text: "home", path: "/" }];
 
 export function Sidebar() {
   const pathname = usePathname();
+  const { isMainnet } = useContext(AbstraxionContext) as AbstraxionContextProps;
 
   const renderNavOptions = () => {
     return NAV_OPTIONS.map((option) => {
+      if (option.text === "home") {
+        return (
+          <div
+            key={option.text}
+            className="ui-flex ui-w-full ui-justify-between ui-px-8"
+          >
+            <Link
+              href={option.path}
+              className={`${
+                pathname === option.path ? "ui-text-white" : "ui-text-slate-400"
+              } ui-font-akkuratLL ui-block ui-mt-8 first:ui-mt-0 ui-leading-3 ui-uppercase ui-tracking-widest ui-text-4xl ui-font-thin`}
+            >
+              {option.text}
+            </Link>
+            <div
+              className={`ui-h-2.5 ui-w-2.5 ${
+                isMainnet ? "ui-bg-mainnet" : "ui-bg-testnet"
+              } ui-rounded-full`}
+            ></div>
+          </div>
+        );
+      }
       return (
         <Link
           key={option.text}
           href={option.path}
           className={`${
-            pathname === option.path
-              ? "ui-text-white ui-font-bold"
-              : "ui-text-slate-400 ui-font-regular"
-          } ui-font-akkuratLL ui-block ui-pl-8 ui-mt-8 first:ui-mt-0 ui-text-xs ui-leading-3 ui-uppercase ui-tracking-widest`}
+            pathname === option.path ? "ui-text-white" : "ui-text-slate-400"
+          } ui-font-akkuratLL ui-block ui-px-8 ui-mt-8 first:ui-mt-0 ui-leading-3 ui-uppercase ui-tracking-widest ui-text-4xl ui-font-thin`}
         >
           {option.text}
         </Link>
@@ -34,16 +52,25 @@ export function Sidebar() {
 
   return (
     <div className="ui-h-screen ui-bg-primary ui-text-white ui-flex ui-flex-col ui-w-64">
-      <div className="ui-flex ui-items-center ui-justify-start ui-pl-8 ui-pt-8">
+      <div className="ui-flex ui-items-center ui-justify-between ui-px-8 ui-pt-8">
         <Image src="/logo.png" alt="Xion Logo" width="90" height="32" />
+        <div
+          className={`ui-flex ${
+            isMainnet ? "ui-bg-mainnet-bg" : "ui-bg-testnet-bg"
+          } ui-px-2 ui-py-1 ui-ml-6 ${
+            isMainnet ? "ui-text-mainnet" : "ui-text-testnet"
+          } ui-rounded-md ui-font-akkuratLL ui-text-xs ui-tracking-widest`}
+        >
+          {isMainnet ? "MAINNET" : "TESTNET"}
+        </div>
       </div>
 
-      <div className="ui-flex-grow ui-mt-14">
+      <div className="ui-flex ui-justify-center ui-flex-col ui-flex-grow ">
         {renderNavOptions()}
         <a
           href={"https://explorer.burnt.com/xion-testnet-1/"}
           target="_blank"
-          className={`${"ui-text-slate-400 ui-font-regular"} ui-font-akkuratLL ui-block ui-pl-8 ui-mt-8 first:ui-mt-0 ui-text-xs ui-leading-3 ui-uppercase ui-tracking-widest`}
+          className={`${"ui-text-slate-400 ui-font-regular"} ui-font-akkuratLL ui-block ui-px-8 ui-mt-16 first:ui-mt-0 ui-font-thin ui-leading-3 ui-text-4xl ui-uppercase ui-tracking-widest`}
         >
           History
         </a>

--- a/apps/abstraxion-dashboard/package.json
+++ b/apps/abstraxion-dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0-alpha.19",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/apps/abstraxion-dashboard/tailwind.config.ts
+++ b/apps/abstraxion-dashboard/tailwind.config.ts
@@ -7,6 +7,10 @@ const config: Config = {
     extend: {
       colors: {
         primary: "#000",
+        mainnet: "#CAF033",
+        "mainnet-bg": "rgba(4, 199, 0, 0.2)",
+        testnet: "#FFAA4A",
+        "testnet-bg": "rgba(255, 170, 74, 0.2)",
       },
       flexGrow: {
         "2": "2",

--- a/apps/demo-app/package.json
+++ b/apps/demo-app/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0-alpha.23",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
- Added visual elements to distinguish between mainnet and testnet
- Updated sidebar nav items to reskinned look

<img width="1440" alt="Screenshot 2024-03-06 at 3 21 11 PM" src="https://github.com/burnt-labs/xion.js/assets/28539040/df6161e3-1423-4fca-af49-4b9ba8ddf70b">
<img width="1440" alt="Screenshot 2024-03-05 at 4 16 54 PM" src="https://github.com/burnt-labs/xion.js/assets/28539040/ecc5986a-1be9-40fa-8186-5e361c4cb87b">
