### PR TITLE
Update casing of "XION" across multiple components

### DIFF
--- a/.changeset/stale-apes-talk.md
+++ b/.changeset/stale-apes-talk.md
@@ -1,0 +1,6 @@
+---
+"abstraxion-dashboard": patch
+"@burnt-labs/constants": patch
+---
+
+Update casing of "XION" from across multiple components

--- a/apps/abstraxion-dashboard/app/layout.tsx
+++ b/apps/abstraxion-dashboard/app/layout.tsx
@@ -32,8 +32,8 @@ const akkuratLL = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "Xion Account Dashboard",
-  description: "A dashboard for managing Xion accounts.",
+  title: "XION Account Dashboard",
+  description: "A dashboard for managing XION accounts.",
 };
 
 export default function RootLayout({

--- a/apps/abstraxion-dashboard/components/Abstraxion/index.tsx
+++ b/apps/abstraxion-dashboard/components/Abstraxion/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef } from "react";
+import { useContext, useEffect } from "react";
 import { GrazProvider } from "graz";
 import { StytchProvider } from "@stytch/nextjs";
 import { ApolloProvider } from "@apollo/client";
@@ -16,7 +16,6 @@ import { ErrorDisplay } from "@/components/ErrorDisplay";
 import { useSearchParams } from "next/navigation";
 import { AbstraxionGrant } from "../AbstraxionGrant";
 import Image from "next/image";
-import { testnetChainInfo } from "@burnt-labs/constants";
 
 export interface ModalProps {
   onClose: VoidFunction;
@@ -116,7 +115,7 @@ export const Abstraxion = ({ isOpen, onClose }: ModalProps) => {
               <a href="https://xion.burnt.com/">
                 <Image
                   src="/logo.png"
-                  alt="Xion Logo"
+                  alt="XION Logo"
                   width="108"
                   height="48"
                 />

--- a/apps/abstraxion-dashboard/components/AccountInfo.tsx
+++ b/apps/abstraxion-dashboard/components/AccountInfo.tsx
@@ -3,7 +3,7 @@ import { CopyIcon, ScanIcon } from "./Icons";
 import { truncateAddress } from "@/utils";
 
 export const AccountInfo = ({ account }: { account?: AbstraxionAccount }) => {
-  const copyXionAddress = () => {
+  const copyXIONAddress = () => {
     if (account?.id) {
       navigator.clipboard.writeText(account?.id);
     }
@@ -34,7 +34,7 @@ export const AccountInfo = ({ account }: { account?: AbstraxionAccount }) => {
         XION Address
       </h3>
       <div
-        onClick={copyXionAddress}
+        onClick={copyXIONAddress}
         className="ui-flex ui-cursor-pointer ui-items-center ui-justify-between ui-mb-10 ui-px-4 ui-w-full ui-h-16 ui-bg-black ui-rounded-lg"
       >
         <p className="ui-text-white ui-text-base ui-font-normal ui-font-akkuratLL ui-leading-normal">

--- a/apps/abstraxion-dashboard/components/Sidebar.tsx
+++ b/apps/abstraxion-dashboard/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import Image from "next/image";
 import { useContext } from "react";
 import { AbstraxionContext, AbstraxionContextProps } from "./AbstraxionContext";
-import { ChevronDownIcon, WalletIcon } from "./Icons";
+import { WalletIcon } from "./Icons";
 
 const NAV_OPTIONS = [{ text: "home", path: "/" }];
 
@@ -56,7 +56,7 @@ export function Sidebar() {
   return (
     <div className="ui-h-screen ui-bg-primary ui-border-[#6C6A6A] ui-border-r-[1px] ui-text-white ui-flex ui-flex-col ui-w-64">
       <div className="ui-flex ui-items-center ui-justify-between ui-px-8 ui-pt-8">
-        <Image src="/logo.png" alt="Xion Logo" width="90" height="32" />
+        <Image src="/logo.png" alt="XION Logo" width="90" height="32" />
         <div
           className={`ui-flex ${
             isMainnet ? "ui-bg-mainnet-bg" : "ui-bg-testnet-bg"

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -55,7 +55,7 @@ const commonInfo: ChainInfo = {
   rpc: "undefined",
   rest: "undefined",
   chainId: "base",
-  chainName: "Xion Testnet",
+  chainName: "XION Testnet",
   bip44: {
     coinType: 118,
   },
@@ -78,7 +78,7 @@ export const testnetChainInfo: ChainInfo = {
   rpc: "https://testnet-rpc.xion-api.com:443",
   rest: "https://testnet-api.xion-api.com:443",
   chainId: "xion-testnet-1",
-  chainName: "Xion Testnet",
+  chainName: "XION Testnet",
 };
 
 export const testChainInfo: ChainInfo = {
@@ -86,5 +86,5 @@ export const testChainInfo: ChainInfo = {
   rpc: "http://localhost:26657",
   rest: "http://localhost:26656",
   chainId: "xion-local-testnet-1",
-  chainName: "Xion Testnet Local",
+  chainName: "XION Testnet Local",
 };


### PR DESCRIPTION
All instances of "Xion" have been updated to "XION" to maintain consistency in branding across the dashboard. This includes updates in alt text for logos, account info, and chain name for both metadata and constants.