### PR TITLE
Disable minification in tsup configuration

### DIFF
--- a/.changeset/fifty-dragons-help.md
+++ b/.changeset/fifty-dragons-help.md
@@ -1,0 +1,9 @@
+---
+"@burnt-labs/abstraxion-core": patch
+"@burnt-labs/abstraxion": patch
+"@burnt-labs/constants": patch
+"@burnt-labs/signers": patch
+"@burnt-labs/ui": patch
+---
+
+Ship unminified code to help with downstream debugging

--- a/packages/abstraxion-core/tsup.config.ts
+++ b/packages/abstraxion-core/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig((options: Options) => ({
   entry: ["src/index.ts"],
   format: ["esm", "cjs"],
   dts: true,
-  minify: true,
+  minify: false,
   clean: true,
   ...options,
 }));

--- a/packages/abstraxion/tsup.config.ts
+++ b/packages/abstraxion/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig((options: Options) => ({
   entry: ["src/index.ts"],
   format: ["esm", "cjs"],
   dts: true,
-  minify: true,
+  minify: false,
   clean: true,
   external: ["react"],
   ...options,

--- a/packages/constants/tsup.config.ts
+++ b/packages/constants/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig((options: Options) => ({
   entry: ["src/index.ts"],
   format: ["esm", "cjs"],
   dts: true,
-  minify: true,
+  minify: false,
   clean: true,
   ...options,
 }));

--- a/packages/signers/tsup.config.ts
+++ b/packages/signers/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig((options: Options) => ({
   entry: ["src/index.ts"],
   format: ["esm", "cjs"],
   dts: true,
-  minify: true,
+  minify: false,
   clean: true,
   ...options,
 }));

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig((options: Options) => ({
   entry: ["src/**/*.tsx"],
   format: ["esm", "cjs"],
   dts: true,
-  minify: true,
+  minify: false,
   clean: true,
   external: ["react"],
   ...options,


### PR DESCRIPTION
The minify option in the tsup configuration for several packages has been set to false. This decision has been reflected in the abstraxion, constants, abstraxion-core, signers, and ui packages. This change will help in improving the debugging process, as the code will no longer be compressed and obfuscated.