### PR TITLE
Update README to replace demo link with quickstart link

### DIFF
--- a/.changeset/hot-fans-battle.md
+++ b/.changeset/hot-fans-battle.md
@@ -1,0 +1,5 @@
+---
+"@burnt-labs/abstraxion": patch
+---
+
+Replace demo link with a link to the quickstart app

--- a/packages/abstraxion/README.md
+++ b/packages/abstraxion/README.md
@@ -12,7 +12,7 @@ npm i @burnt-labs/abstraxion
 
 ## Basic Usage
 
-Find an implementation demo here: [abstraxion demo](../../apps/demo-app)
+Get started [here](https://quickstart.dev.testnet.burnt.com/)
 
 First, wrap your app in the `AbstraxionProvider` at the top level with the appropriate config
 

--- a/packages/abstraxion/README.md
+++ b/packages/abstraxion/README.md
@@ -10,9 +10,17 @@ Run the following:
 npm i @burnt-labs/abstraxion
 ```
 
-## Basic Usage
+## Xion Quick Start Integration
 
-Get started [here](https://quickstart.dev.testnet.burnt.com/)
+If you're new to Xion blockchain development, we recommend using our Quick Start tool before integrating Abstraxion into your custom project.
+
+Visit [quickstart.dev.testnet.burnt.com](https://quickstart.dev.testnet.burnt.com) to deploy the necessary contracts (UserMap and treasury) with a single click, and automatically generate the environment variables required for Abstraxion integration.
+
+This tool eliminates the complexity of manual contract deployment and configuration, allowing you to start building with Abstraxion immediately. The deployed contracts provide gasless transactions and data storage capabilities essential for most dApps.
+
+For full documentation on the Quick Start approach, see our [Zero to dApp in 5 Minutes](https://docs.burnt.com/xion/developers/xion-quick-start/zero-to-dapp-in-5-minutes/launch-a-user-map-dapp-on-xion-in-5-minutes) guide.
+
+## Basic Usage
 
 First, wrap your app in the `AbstraxionProvider` at the top level with the appropriate config
 


### PR DESCRIPTION
Replaced the outdated demo link in the README with a link to the quickstart app for easier onboarding. This improves accessibility to the setup guide and ensures users are directed to the most relevant resource.