### PR TITLE
feat(demo-app): add custom UI and legacy UI examples

### DIFF
--- a/.changeset/common-bobcats-ask.md
+++ b/.changeset/common-bobcats-ask.md
@@ -1,0 +1,11 @@
+---
+"demo-app": minor
+---
+
+Add custom UI and legacy UI examples to demo app
+
+- Added custom UI example showing how to use Abstraxion without the default modal
+- Added legacy UI example demonstrating the traditional modal approach
+- Updated main page to serve as navigation between the two examples
+- Custom UI provides full control over loading states and user experience
+- Legacy UI uses the built-in Abstraxion modal component

--- a/apps/demo-app/src/app/default-ui/page.tsx
+++ b/apps/demo-app/src/app/default-ui/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+import { useState } from "react";
+import {
+  Abstraxion,
+  useAbstraxionAccount,
+  useAbstraxionSigningClient,
+  useModal,
+} from "@burnt-labs/abstraxion";
+import { Button } from "@burnt-labs/ui";
+import "@burnt-labs/ui/dist/index.css";
+import "@burnt-labs/abstraxion/dist/index.css";
+import Link from "next/link";
+
+export default function DefaultUIPage(): JSX.Element {
+  const { data: account } = useAbstraxionAccount();
+  const { client, logout } = useAbstraxionSigningClient();
+  const [showModal, setShowModal] = useModal();
+
+  return (
+    <main className="m-auto flex min-h-screen max-w-lg flex-col items-center justify-center gap-4 p-4">
+      <h1 className="text-2xl font-bold tracking-tighter text-white">
+        Legacy UI Abstraxion Example
+      </h1>
+      <p className="text-center text-gray-400">
+        This example uses the legacy Abstraxion modal UI for wallet connection.
+        Click the button below to open the modal.
+      </p>
+      
+      <div className="w-full space-y-4">
+        <Button
+          fullWidth
+          onClick={() => setShowModal(true)}
+          structure="base"
+        >
+          {account.bech32Address ? (
+            <div className="flex items-center justify-center">
+              VIEW ACCOUNT
+            </div>
+          ) : (
+            "CONNECT WITH ABSTRAXION MODAL"
+          )}
+        </Button>
+
+        {account.bech32Address && (
+          <>
+            <div className="rounded border border-white/20 p-4">
+              <h3 className="mb-2 font-semibold">Account Info</h3>
+              <p className="text-sm text-gray-400">
+                Address: {account.bech32Address}
+              </p>
+              <p className="text-sm text-gray-400">
+                Client: {client ? "Connected" : "Not connected"}
+              </p>
+            </div>
+            
+            <Button
+              fullWidth
+              onClick={() => {
+                if (logout) logout();
+              }}
+              structure="outlined"
+            >
+              DISCONNECT
+            </Button>
+          </>
+        )}
+      </div>
+
+      <Abstraxion
+        onClose={() => {
+          setShowModal(false);
+        }}
+      />
+
+      <Link href="/" className="mt-4 inline-block text-sm text-gray-400 underline hover:text-gray-300">
+        ← Back to examples
+      </Link>
+    </main>
+  );
+}

--- a/apps/demo-app/src/app/loading-state/page.tsx
+++ b/apps/demo-app/src/app/loading-state/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+export default function LoadingStatePage() {
+  return (
+    <main className="m-auto flex min-h-screen max-w-xs flex-col items-center justify-center gap-4 p-4">
+      <div className="rounded border border-white/20 p-6 text-center">
+        <p className="font-bold">You are being redirected...</p>
+        <p className="text-sm">
+          Use custom UI to render loading state with your own branding
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/demo-app/src/app/page.tsx
+++ b/apps/demo-app/src/app/page.tsx
@@ -1,188 +1,28 @@
 "use client";
 import Link from "next/link";
-import { useState } from "react";
-import {
-  useAbstraxionAccount,
-  useAbstraxionSigningClient,
-} from "@burnt-labs/abstraxion";
 import { Button } from "@burnt-labs/ui";
 import "@burnt-labs/ui/dist/index.css";
-import type { InstantiateResult } from "@cosmjs/cosmwasm-stargate";
-import { SignArb } from "../components/sign-arb.tsx";
-
-type InstantiateResultOrUndefined = InstantiateResult | undefined;
 
 export default function Page(): JSX.Element {
-  // Abstraxion hooks
-  const { data: account, login, logout, isConnecting } = useAbstraxionAccount();
-  const { client, signArb } = useAbstraxionSigningClient();
 
-  // General state hooks
-  const [isLoggingIn, setIsLoggingIn] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [instantiateResult, setInstantiateResult] =
-    useState<InstantiateResultOrUndefined>(undefined);
-
-  const blockExplorerUrl = `https://www.mintscan.io/xion-testnet/tx/${instantiateResult?.transactionHash}`;
-
-  async function claimSeat(): Promise<void> {
-    setLoading(true);
-
-    try {
-      // Use "auto" fee for most transactions
-      // Sample treasury contract instantiate msg
-      const msg = {
-        type_urls: ["/cosmwasm.wasm.v1.MsgInstantiateContract"],
-        grant_configs: [
-          {
-            description: "Ability to instantiate contracts",
-            optional: false,
-            authorization: {
-              type_url: "/cosmos.authz.v1beta1.GenericAuthorization",
-              value: "CigvY29zbXdhc20ud2FzbS52MS5Nc2dJbnN0YW50aWF0ZUNvbnRyYWN0",
-            },
-          },
-        ],
-        fee_config: {
-          description: "Sample fee config for testnet-2",
-          allowance: {
-            type_url: "/cosmos.feegrant.v1beta1.BasicAllowance",
-            value: "Cg8KBXV4aW9uEgY1MDAwMDA=",
-          },
-        },
-        admin: account.bech32Address,
-      };
-
-      const instantiateRes = await client?.instantiate(
-        account.bech32Address,
-        33,
-        msg,
-        "instantiate on expo demo",
-        "auto",
-      );
-
-      console.log(instantiateRes);
-
-      if (!instantiateRes) {
-        throw new Error("Instantiate failed.");
-      }
-
-      // Default cosmsjs gas multiplier for simulation is 1.4
-      // If you're finding that transactions are undersimulating, you can bump up the gas multiplier by setting fee to a number, ex. 1.5
-      // Fee amounts shouldn't stray too far away from the defaults
-      // Example:
-      // const instantiateRes = await client?.instantiate(
-      //   account.bech32Address,
-      //   33,
-      //   msg,
-      //   "instantiate on expo demo",
-      //   1.5
-      // );
-
-      setInstantiateResult(instantiateRes);
-    } catch (error) {
-      // eslint-disable-next-line no-console -- No UI exists yet to display errors
-      console.log(error);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  const handleLogin = async () => {
-    try {
-      setIsLoggingIn(true);
-      await login();
-    } catch (error) {
-      console.error("There's been an error loggin in");
-    } finally {
-      setIsLoggingIn(false);
-    }
-  };
-
-  if (isLoggingIn) {
-    return (
-      <main className="m-auto flex min-h-screen max-w-xs flex-col items-center justify-center gap-4 p-4">
-        <div className="rounded border border-white/20 p-6 text-center">
-          <p className="font-bold">You are being redirected...</p>
-          <p className="text-sm">
-            Use custom UI to render loading state with your own branding
-          </p>
-        </div>
-      </main>
-    );
-  }
 
   return (
     <main className="m-auto flex min-h-screen max-w-xs flex-col items-center justify-center gap-4 p-4">
       <h1 className="text-2xl font-bold tracking-tighter text-white">
         ABSTRAXION
       </h1>
-      <Button
-        fullWidth
-        onClick={handleLogin}
-        structure="base"
-        disabled={isConnecting}
-      >
-        {account.bech32Address ? (
-          <div className="flex items-center justify-center">VIEW ACCOUNT</div>
-        ) : isConnecting ? (
-          "LOADING..."
-        ) : (
-          "CONNECT"
-        )}
-      </Button>
-      {client ? (
-        <>
-          <Button
-            disabled={loading}
-            fullWidth
-            onClick={() => {
-              void claimSeat();
-            }}
-            structure="base"
-          >
-            {loading ? "LOADING..." : "Instantiate Sample Treasury"}
+      <div className="flex w-full flex-col gap-2">
+        <Link href="/ui-less">
+          <Button fullWidth structure="outlined">
+            CUSTOM UI EXAMPLE
           </Button>
-          {logout ? (
-            <Button
-              disabled={loading}
-              fullWidth
-              onClick={() => {
-                logout();
-              }}
-              structure="base"
-            >
-              LOGOUT
-            </Button>
-          ) : null}
-          {signArb ? <SignArb /> : null}
-        </>
-      ) : null}
-      {instantiateResult ? (
-        <div className="flex flex-col rounded border-2 border-black p-2 dark:border-white">
-          <div className="mt-2">
-            <p className="text-zinc-500">
-              <span className="font-bold">Transaction Hash</span>
-            </p>
-            <p className="text-sm">{instantiateResult.transactionHash}</p>
-          </div>
-          <div className="mt-2">
-            <p className=" text-zinc-500">
-              <span className="font-bold">Block Height:</span>
-            </p>
-            <p className="text-sm">{instantiateResult.height}</p>
-          </div>
-          <div className="mt-2">
-            <Link
-              className="text-black underline visited:text-purple-600 dark:text-white"
-              href={blockExplorerUrl}
-              target="_blank"
-            >
-              View in Block Explorer
-            </Link>
-          </div>
-        </div>
-      ) : null}
+        </Link>
+        <Link href="/default-ui">
+          <Button fullWidth structure="outlined">
+            LEGACY UI EXAMPLE
+          </Button>
+        </Link>
+      </div>
     </main>
   );
 }

--- a/apps/demo-app/src/app/ui-less/page.tsx
+++ b/apps/demo-app/src/app/ui-less/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+import { useState } from "react";
+import {
+  useAbstraxionAccount,
+  useAbstraxionSigningClient,
+} from "@burnt-labs/abstraxion";
+import { Button } from "@burnt-labs/ui";
+import "@burnt-labs/ui/dist/index.css";
+import Link from "next/link";
+
+export default function UILessPage(): JSX.Element {
+  const { data: account, login, logout, isConnecting } = useAbstraxionAccount();
+  const { client } = useAbstraxionSigningClient();
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
+
+  const handleLogin = async () => {
+    try {
+      setIsLoggingIn(true);
+      await login();
+    } catch (error) {
+      console.error("Error logging in:", error);
+    } finally {
+      setIsLoggingIn(false);
+    }
+  };
+
+  if (isLoggingIn) {
+    return (
+      <main className="m-auto flex min-h-screen max-w-xs flex-col items-center justify-center gap-4 p-4">
+        <div className="rounded border border-white/20 p-6 text-center">
+          <p className="font-bold">You are being redirected...</p>
+          <p className="text-sm">
+            This is a custom loading UI - you can style this however you want!
+          </p>
+          <div className="mt-4">
+            <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-r-transparent"></div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="m-auto flex min-h-screen max-w-lg flex-col items-center justify-center gap-4 p-4">
+      <h1 className="text-2xl font-bold tracking-tighter text-white">
+        Custom UI Abstraxion Example
+      </h1>
+      <p className="text-center text-gray-400">
+        This example demonstrates using Abstraxion with a custom UI instead of the default modal.
+        The login flow redirects to an external page and returns to the app.
+      </p>
+      
+      <div className="w-full space-y-4">
+        <Button
+          fullWidth
+          onClick={handleLogin}
+          structure="base"
+          disabled={isConnecting}
+        >
+          {account.bech32Address ? (
+            <div className="flex items-center justify-center">
+              Connected: {account.bech32Address.slice(0, 10)}...
+            </div>
+          ) : isConnecting ? (
+            "LOADING..."
+          ) : (
+            "CONNECT WALLET"
+          )}
+        </Button>
+
+        {account.bech32Address && (
+          <>
+            <div className="rounded border border-white/20 p-4">
+              <h3 className="mb-2 font-semibold">Account Info</h3>
+              <p className="text-sm text-gray-400">
+                Address: {account.bech32Address}
+              </p>
+              <p className="text-sm text-gray-400">
+                Client: {client ? "Connected" : "Not connected"}
+              </p>
+            </div>
+            
+            <Button
+              fullWidth
+              onClick={() => logout()}
+              structure="outlined"
+            >
+              DISCONNECT
+            </Button>
+          </>
+        )}
+      </div>
+
+      <Link href="/" className="mt-4 inline-block text-sm text-gray-400 underline hover:text-gray-300">
+        ← Back to examples
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Added custom UI example showing how to use Abstraxion without the default modal
- Added legacy UI example demonstrating the traditional modal approach  
- Transformed main page into navigation hub between examples

## Description
This PR adds two new example implementations to the demo app as requested in commit 7b4de39:

### Custom UI Example (`/ui-less`)
- Shows how to implement Abstraxion without using the default modal
- Provides custom loading state during authentication redirect
- Gives developers full control over the UI/UX

### Legacy UI Example (`/default-ui`)  
- Demonstrates the traditional modal-based approach
- Uses the built-in `<Abstraxion>` component
- Shows the standard modal UI for wallet connection

The main page has been simplified to serve as navigation between these two examples, removing the previous inline implementation.

## Test Plan
- [ ] Run `pnpm dev` and navigate to the demo app
- [ ] Click "CUSTOM UI EXAMPLE" and test wallet connection with custom loading state
- [ ] Click "LEGACY UI EXAMPLE" and test wallet connection with modal
- [ ] Verify back navigation works from both example pages
- [ ] Test disconnect functionality in both examples