### PR TITLE
feat: use treasury worker API for server-side grant validation

### DIFF
--- a/packages/abstraxion-core/src/AbstraxionAuth.ts
+++ b/packages/abstraxion-core/src/AbstraxionAuth.ts
@@ -31,6 +31,7 @@ export class AbstraxionAuth {
   callbackUrl?: string;
   treasury?: string;
   treasuryIndexerUrl?: string;
+  treasuryApiUrl?: string;
   gasPrice?: string;
 
   // Signer
@@ -73,8 +74,9 @@ export class AbstraxionAuth {
    * @param {SpendLimit[]} [bank] - The spend limits for the user.
    * @param {string} callbackUrl - preferred callback url to override default
    * @param {string} treasury - treasury contract instance address
-   * @param {string} treasuryIndexerUrl - custom indexer URL for treasury grant configs (DaoDao indexer)
+   * @param {string} treasuryIndexerUrl - custom indexer URL for treasury grant configs (DaoDao indexer). Deprecated: use treasuryApiUrl instead.
    * @param {string} gasPrice - Gas price string (e.g., "0.001uxion"). Defaults to "0.001uxion" if not provided.
+   * @param {string} treasuryApiUrl - Treasury worker API URL for server-side grant validation. When set, pollForGrants() delegates to the worker instead of doing client-side comparison.
    */
   configureAbstraxionInstance(
     rpc: string,
@@ -85,6 +87,7 @@ export class AbstraxionAuth {
     treasury?: string,
     treasuryIndexerUrl?: string,
     gasPrice?: string,
+    treasuryApiUrl?: string,
   ) {
     this.rpcUrl = rpc;
     this.grantContracts = grantContracts;
@@ -93,6 +96,7 @@ export class AbstraxionAuth {
     this.callbackUrl = callbackUrl;
     this.treasury = treasury;
     this.treasuryIndexerUrl = treasuryIndexerUrl;
+    this.treasuryApiUrl = treasuryApiUrl;
     this.gasPrice = gasPrice;
   }
 
@@ -479,14 +483,28 @@ export class AbstraxionAuth {
 
     while (retries < maxRetries) {
       try {
+        // Treasury mode with treasury worker API: delegate grant validation entirely
+        // to the server. This eliminates the DaoDao indexer dependency on the client,
+        // avoids client-side protobuf decoding and ABCI queries, and leverages the
+        // worker's caching (30s Cache-Control) and racing strategy (DaoDao + direct
+        // RPC via Promise.any) for better performance and reliability.
+        if (this.treasury && this.treasuryApiUrl) {
+          return await this.checkGrantsViaApi(
+            this.treasuryApiUrl,
+            this.treasury,
+            grantee,
+            granter,
+          );
+        }
+
         let data: GrantsResponse;
         let treasuryGrantConfigs: TreasuryGrantConfig[] | undefined;
 
-        // If treasury mode, fetch both chain grants and treasury configs in parallel
+        // Treasury mode with client-side comparison (legacy path when treasuryApiUrl is not set)
         if (this.treasury) {
           if (!this.treasuryIndexerUrl) {
             throw new Error(
-              "Treasury indexer URL is required when using treasury mode",
+              "Treasury indexer URL is required when using treasury mode without treasuryApiUrl",
             );
           }
 
@@ -539,6 +557,51 @@ export class AbstraxionAuth {
       }
     }
     return false;
+  }
+
+  /**
+   * Validates grants by calling the treasury worker's /check-grants endpoint.
+   *
+   * This offloads grant validation to the server, which:
+   * - Fetches treasury config (via DaoDao indexer racing with direct RPC)
+   * - Fetches on-chain grants via ABCI query
+   * - Decodes and compares both sets of grants
+   * - Returns a simple match/valid/expiration result
+   *
+   * This approach is preferred over client-side validation because it:
+   * 1. Eliminates the client's dependency on the DaoDao indexer
+   * 2. Avoids shipping protobuf decoding logic to the browser
+   * 3. Leverages server-side caching (30s) for better performance
+   * 4. Centralizes grant comparison logic in one place (the treasury worker)
+   */
+  private async checkGrantsViaApi(
+    treasuryApiUrl: string,
+    treasuryAddress: string,
+    grantee: string,
+    granter: string,
+  ): Promise<boolean> {
+    const url = new URL(
+      `/treasury/${treasuryAddress}/check-grants`,
+      treasuryApiUrl,
+    );
+    url.searchParams.set("grantee", grantee);
+    url.searchParams.set("granter", granter);
+
+    const response = await fetch(url.toString());
+
+    if (!response.ok) {
+      throw new Error(
+        `Treasury grant check failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const result: {
+      match: boolean;
+      hasValidGrants: boolean;
+      earliestExpiration: string | null;
+    } = await response.json();
+
+    return result.match && result.hasValidGrants;
   }
 
   /**

--- a/packages/abstraxion/src/controllers/RedirectController.ts
+++ b/packages/abstraxion/src/controllers/RedirectController.ts
@@ -16,7 +16,7 @@ import {
   getAccountInfoFromRestored,
 } from "@burnt-labs/account-management";
 import type { AccountInfo } from "@burnt-labs/account-management";
-import { getDaoDaoIndexerUrl } from "@burnt-labs/constants";
+import { getDaoDaoIndexerUrl, getTreasuryApiUrl } from "@burnt-labs/constants";
 import { BaseController } from "./BaseController";
 import type { ControllerConfig } from "./types";
 import type { RedirectAuthentication } from "../types";
@@ -123,9 +123,12 @@ export class RedirectController extends BaseController {
       config.redirectStrategy,
     );
 
-    // Configure AbstraxionAuth with default treasury indexer URL
+    // Configure AbstraxionAuth with treasury API URL (preferred) and DaoDao indexer (fallback)
     const treasuryIndexerUrl = config.treasury
       ? getDaoDaoIndexerUrl(config.chainId)
+      : undefined;
+    const treasuryApiUrl = config.treasury
+      ? getTreasuryApiUrl(config.chainId)
       : undefined;
 
     this.abstraxionAuth.configureAbstraxionInstance(
@@ -135,8 +138,9 @@ export class RedirectController extends BaseController {
       config.bank, // Pass bank (or minimal fallback) if provided
       config.redirect.callbackUrl,
       config.treasury, // Pass treasury so it's included in redirect URL
-      treasuryIndexerUrl, // Default DaoDao indexer URL for treasury grant queries
+      treasuryIndexerUrl, // DaoDao indexer URL (fallback when treasuryApiUrl not available)
       config.gasPrice, // Pass gasPrice for signing client creation
+      treasuryApiUrl, // Treasury worker API for server-side grant validation
     );
 
     // Create grant config

--- a/packages/abstraxion/src/controllers/factory.ts
+++ b/packages/abstraxion/src/controllers/factory.ts
@@ -9,6 +9,7 @@ import { AbstraxionAuth } from "@burnt-labs/abstraxion-core";
 import type { Controller } from "./index";
 import { RedirectController, SignerController } from "./index";
 import type { NormalizedAbstraxionConfig } from "../types";
+import { getTreasuryApiUrl } from "@burnt-labs/constants";
 
 /**
  * Create a controller based on authentication config
@@ -42,6 +43,9 @@ export function createController(
         ? config.authentication
         : undefined;
     const treasuryIndexerConfig = signerAuth?.treasuryIndexer;
+    const treasuryApiUrl = config.treasury
+      ? getTreasuryApiUrl(config.chainId)
+      : undefined;
 
     // Configure AbstraxionAuth for signer mode
     // Note: Account indexer (Numia/Subquery) is handled by SignerController via account-management,
@@ -55,6 +59,7 @@ export function createController(
       config.treasury,
       treasuryIndexerConfig?.url,
       config.gasPrice,
+      treasuryApiUrl,
     );
 
     // Delegate to SignerController's factory method

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -119,6 +119,11 @@ const FEE_GRANTERS: Record<string, string> = {
   "xion-testnet-2": "xion1xrqz2wpt4rw8rtdvrc4n4yn5h54jm0nn4evn2x",
 };
 
+const TREASURY_API_URLS: Record<string, string> = {
+  "xion-mainnet-1": "https://treasury-api.burnt.com",
+  "xion-testnet-2": "https://treasury-api.testnet.burnt.com",
+};
+
 const DAODAO_INDEXER_URLS: Record<string, string> = {
   "xion-mainnet-1": "https://daodaoindexer.burnt.com",
   "xion-testnet-1": "https://daodaoindexer.burnt.com",
@@ -139,6 +144,10 @@ export function getFeeGranter(chainId: string): string {
 
 export function getDaoDaoIndexerUrl(chainId: string): string {
   return DAODAO_INDEXER_URLS[chainId] || "https://daodaoindexer.burnt.com";
+}
+
+export function getTreasuryApiUrl(chainId: string): string | undefined {
+  return TREASURY_API_URLS[chainId];
 }
 
 export function getRpcUrl(chainId: string): string | undefined {


### PR DESCRIPTION
## Summary

- Adds `getTreasuryApiUrl(chainId)` to `@burnt-labs/constants` with mainnet/testnet URLs
- Adds `treasuryApiUrl` config to `AbstraxionAuth` and new `checkGrantsViaApi()` method
- When `treasuryApiUrl` is set, `pollForGrants()` calls the treasury worker's `GET /treasury/{address}/check-grants?grantee=X&granter=Y` endpoint instead of doing client-side grant comparison
- Falls back to existing client-side path (DaoDao indexer + protobuf decoding) when `treasuryApiUrl` is not available
- All controllers (Redirect, Iframe, Popup, Signer/factory) auto-resolve `treasuryApiUrl` from chain ID

### Why

Grant validation currently requires the client to:
1. Query the DaoDao indexer (or RPC) for treasury config
2. Query the chain for on-chain grants via ABCI
3. Decode protobuf authorizations
4. Compare the two sets

By delegating to the treasury worker's `/check-grants` endpoint, we:
- **Eliminate the client's DaoDao indexer dependency** — the worker handles this internally with a racing strategy (DaoDao + direct RPC via `Promise.any`)
- **Reduce browser bundle size** — no need to ship protobuf decoding logic
- **Leverage server-side caching** (30s `Cache-Control`) for better performance
- **Centralize grant comparison logic** in one place (the treasury worker)

## Test plan

- [x] `abstraxion-core` tests pass (255 passed)
- [x] `abstraxion` controller tests pass (30 passed)
- [x] TypeScript type-checks clean across all modified packages
- [ ] Manual test with treasury-enabled dApp to verify grant validation via API