### PR TITLE
04 - feat(abstraxion-js): extract createAbstraxionRuntime, add RN embedded…

### DIFF
--- a/.changeset/abstraxion-js-runtime.md
+++ b/.changeset/abstraxion-js-runtime.md
@@ -1,0 +1,5 @@
+---
+"@burnt-labs/abstraxion-js": major
+---
+
+feat(abstraxion-js): extract `createAbstraxionRuntime` — a framework-agnostic runtime (subscribe/login/logout/manageAuthenticators + `createReadClient`/`createDirectSigningClient`) that React, React Native, and the Svelte/vanilla demos all consume, removing duplicated controller-narrowing logic. Adds React Native embedded (WebView iframe) transport strategies and unifies the hook surface.

--- a/demos/react-native/README.md
+++ b/demos/react-native/README.md
@@ -6,9 +6,17 @@ Expo + React Native demo for `@burnt-labs/abstraxion-react-native`.
 
 - Expo SDK 54 (React Native 0.81 / React 19 / new architecture)
 - Expo Router (file-based routing under `src/app/`)
-- `@burnt-labs/abstraxion-react-native` with redirect auth as the primary flow
+- `@burnt-labs/abstraxion-react-native` with redirect auth (primary) and embedded WebView (Phase 9b)
 - AsyncStorage + Expo WebBrowser/Linking under the hood (already wired in the SDK)
 - `react-native-get-random-values` + `react-native-quick-crypto` polyfills for signing
+- `react-native-webview` for the embedded screen (only used on `/embedded`)
+
+## Routes
+
+| Route | Auth mode | Notes |
+| --- | --- | --- |
+| `/` | `redirect` | Expo WebBrowser auth session + deep link callback. |
+| `/embedded` | `embedded` | Dashboard runs inside an in-app `<WebView>` via `<AbstraxionEmbed>`. |
 
 ## Setup
 

--- a/demos/react-native/README.md
+++ b/demos/react-native/README.md
@@ -13,9 +13,9 @@ Expo + React Native demo for `@burnt-labs/abstraxion-react-native`.
 
 ## Routes
 
-| Route | Auth mode | Notes |
-| --- | --- | --- |
-| `/` | `redirect` | Expo WebBrowser auth session + deep link callback. |
+| Route       | Auth mode  | Notes                                                                |
+| ----------- | ---------- | -------------------------------------------------------------------- |
+| `/`         | `redirect` | Expo WebBrowser auth session + deep link callback.                   |
 | `/embedded` | `embedded` | Dashboard runs inside an in-app `<WebView>` via `<AbstraxionEmbed>`. |
 
 ## Setup

--- a/demos/react-native/package.json
+++ b/demos/react-native/package.json
@@ -27,7 +27,8 @@
     "react-native-quick-crypto": "^0.7.17",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "react-native-webview": "13.13.5"
   },
   "devDependencies": {
     "@types/react": "~19.1.10",

--- a/demos/react-native/src/app/_layout.tsx
+++ b/demos/react-native/src/app/_layout.tsx
@@ -3,25 +3,31 @@ import "@/setup/crypto";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import { AbstraxionProvider } from "@burnt-labs/abstraxion-react-native";
 
-const config = {
-  chainId: process.env.EXPO_PUBLIC_CHAIN_ID ?? "xion-testnet-2",
-  rpcUrl:
-    process.env.EXPO_PUBLIC_RPC_URL ?? "https://rpc.xion-testnet-2.burnt.com",
-  restUrl:
-    process.env.EXPO_PUBLIC_REST_URL ?? "https://api.xion-testnet-2.burnt.com",
-  gasPrice: process.env.EXPO_PUBLIC_GAS_PRICE ?? "0.001uxion",
-  treasury: process.env.EXPO_PUBLIC_TREASURY_ADDRESS,
-};
-
+/**
+ * Each route has its own AbstraxionProvider so we can demonstrate redirect
+ * mode (`/`) and embedded WebView mode (`/embedded`) side-by-side without one
+ * provider's auth mode leaking into the other.
+ */
 export default function RootLayout(): JSX.Element {
   return (
     <SafeAreaProvider>
-      <AbstraxionProvider config={config}>
-        <Stack screenOptions={{ headerShown: false }} />
-        <StatusBar style="light" />
-      </AbstraxionProvider>
+      <Stack
+        screenOptions={{
+          headerStyle: { backgroundColor: "#000" },
+          headerTintColor: "#fff",
+        }}
+      >
+        <Stack.Screen
+          name="index"
+          options={{ title: "XION · Redirect" }}
+        />
+        <Stack.Screen
+          name="embedded"
+          options={{ title: "XION · Embedded" }}
+        />
+      </Stack>
+      <StatusBar style="light" />
     </SafeAreaProvider>
   );
 }

--- a/demos/react-native/src/app/_layout.tsx
+++ b/demos/react-native/src/app/_layout.tsx
@@ -18,14 +18,8 @@ export default function RootLayout(): JSX.Element {
           headerTintColor: "#fff",
         }}
       >
-        <Stack.Screen
-          name="index"
-          options={{ title: "XION · Redirect" }}
-        />
-        <Stack.Screen
-          name="embedded"
-          options={{ title: "XION · Embedded" }}
-        />
+        <Stack.Screen name="index" options={{ title: "XION · Redirect" }} />
+        <Stack.Screen name="embedded" options={{ title: "XION · Embedded" }} />
       </Stack>
       <StatusBar style="light" />
     </SafeAreaProvider>

--- a/demos/react-native/src/app/embedded.tsx
+++ b/demos/react-native/src/app/embedded.tsx
@@ -1,0 +1,195 @@
+/**
+ * Embedded-mode demo (Phase 9b).
+ *
+ * Mounts the dashboard inside an in-app `<WebView>` via the new
+ * `<AbstraxionEmbed>` component. Login, grant approval, and manage-authenticators
+ * happen entirely inside the WebView — no Expo WebBrowser session, no deep
+ * link round-trip.
+ *
+ * Requires `react-native-webview` to be installed at the consumer level.
+ */
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { Link } from "expo-router";
+import {
+  AbstraxionEmbed,
+  AbstraxionProvider,
+  useAbstraxionAccount,
+  useManageAuthenticators,
+} from "@burnt-labs/abstraxion-react-native";
+
+const config = {
+  chainId: process.env.EXPO_PUBLIC_CHAIN_ID ?? "xion-testnet-2",
+  rpcUrl:
+    process.env.EXPO_PUBLIC_RPC_URL ?? "https://rpc.xion-testnet-2.burnt.com",
+  restUrl:
+    process.env.EXPO_PUBLIC_REST_URL ?? "https://api.xion-testnet-2.burnt.com",
+  gasPrice: process.env.EXPO_PUBLIC_GAS_PRICE ?? "0.001uxion",
+  treasury: process.env.EXPO_PUBLIC_TREASURY_ADDRESS,
+  authentication: { type: "embedded" as const },
+};
+
+export default function EmbeddedRoute(): JSX.Element {
+  return (
+    <AbstraxionProvider config={config}>
+      <EmbeddedScreen />
+    </AbstraxionProvider>
+  );
+}
+
+function EmbeddedScreen(): JSX.Element {
+  const {
+    data: account,
+    login,
+    logout,
+    isConnected,
+    isConnecting,
+    isInitializing,
+  } = useAbstraxionAccount();
+  const { manageAuthenticators, isSupported } = useManageAuthenticators();
+  const [manageStatus, setManageStatus] = useState<
+    "idle" | "pending" | "success" | "error"
+  >("idle");
+
+  const handleManage = async () => {
+    setManageStatus("pending");
+    try {
+      await manageAuthenticators();
+      setManageStatus("success");
+    } catch {
+      setManageStatus("error");
+    }
+  };
+
+  const showSignIn = !isInitializing && !isConnected;
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title}>Embedded WebView</Text>
+        <Text style={styles.subtitle}>
+          The dashboard runs inside this app via react-native-webview.
+        </Text>
+
+        <Link href="/" asChild>
+          <Pressable style={styles.linkRow}>
+            <Text style={styles.linkText}>← Back to redirect mode</Text>
+          </Pressable>
+        </Link>
+
+        {isInitializing && (
+          <View style={styles.row}>
+            <ActivityIndicator size="small" color="#fbbf24" />
+            <Text style={styles.muted}>Restoring session…</Text>
+          </View>
+        )}
+
+        {showSignIn && (
+          <View style={styles.signInWrapper}>
+            <Pressable
+              onPress={() => login().catch(() => undefined)}
+              disabled={isConnecting}
+              style={styles.signInButton}
+            >
+              <Text style={styles.signInButtonText}>
+                {isConnecting ? "Opening…" : "Sign in with XION"}
+              </Text>
+            </Pressable>
+          </View>
+        )}
+
+        {isConnected && account.bech32Address && (
+          <View style={styles.card}>
+            <Text style={styles.cardLabel}>Connected as</Text>
+            <Text style={styles.address} selectable>
+              {account.bech32Address}
+            </Text>
+            {isSupported && (
+              <Pressable onPress={handleManage} style={styles.outlinedButton}>
+                <Text style={styles.outlinedButtonText}>
+                  {manageStatus === "pending"
+                    ? "OPENING…"
+                    : "MANAGE AUTHENTICATORS"}
+                </Text>
+              </Pressable>
+            )}
+            {manageStatus === "success" && (
+              <Text style={styles.success}>Authenticators updated.</Text>
+            )}
+            <Pressable onPress={() => logout()} style={styles.outlinedButton}>
+              <Text style={[styles.outlinedButtonText, styles.disconnect]}>
+                DISCONNECT
+              </Text>
+            </Pressable>
+          </View>
+        )}
+      </ScrollView>
+
+      {/* Embed handles the WebView + approval modal only. Idle button is
+          rendered in-flow above so it sits with the rest of the content. */}
+      <AbstraxionEmbed
+        idleView="hidden"
+        connectedView="hidden"
+        approvalView="modal"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#000" },
+  content: { padding: 24, gap: 16 },
+  title: { color: "#fff", fontSize: 22, fontWeight: "700" },
+  subtitle: { color: "#9ca3af", fontSize: 13 },
+  row: { flexDirection: "row", alignItems: "center", gap: 8 },
+  muted: { color: "#9ca3af", fontSize: 13 },
+  card: {
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.1)",
+    borderRadius: 8,
+    padding: 16,
+    gap: 12,
+  },
+  cardLabel: { color: "#9ca3af", fontSize: 12 },
+  address: { color: "#4ade80", fontSize: 13, fontFamily: "Courier" },
+  outlinedButton: {
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.2)",
+    borderRadius: 6,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  outlinedButtonText: {
+    color: "#fff",
+    fontSize: 13,
+    fontWeight: "600",
+    letterSpacing: 1,
+  },
+  disconnect: { color: "#f87171" },
+  success: { color: "#4ade80", fontSize: 12 },
+  linkRow: { paddingVertical: 6 },
+  linkText: { color: "#60a5fa", fontSize: 13 },
+  signInWrapper: {
+    marginTop: 24,
+    alignItems: "center",
+  },
+  signInButton: {
+    backgroundColor: "#fff",
+    paddingVertical: 14,
+    paddingHorizontal: 32,
+    borderRadius: 24,
+  },
+  signInButtonText: {
+    color: "#000",
+    fontWeight: "700",
+    letterSpacing: 1,
+    fontSize: 13,
+  },
+});

--- a/demos/react-native/src/app/index.tsx
+++ b/demos/react-native/src/app/index.tsx
@@ -7,10 +7,30 @@ import {
   Text,
   View,
 } from "react-native";
+import { Link } from "expo-router";
 import {
+  AbstraxionProvider,
   useAbstraxionAccount,
   useManageAuthenticators,
 } from "@burnt-labs/abstraxion-react-native";
+
+const config = {
+  chainId: process.env.EXPO_PUBLIC_CHAIN_ID ?? "xion-testnet-2",
+  rpcUrl:
+    process.env.EXPO_PUBLIC_RPC_URL ?? "https://rpc.xion-testnet-2.burnt.com",
+  restUrl:
+    process.env.EXPO_PUBLIC_REST_URL ?? "https://api.xion-testnet-2.burnt.com",
+  gasPrice: process.env.EXPO_PUBLIC_GAS_PRICE ?? "0.001uxion",
+  treasury: process.env.EXPO_PUBLIC_TREASURY_ADDRESS,
+};
+
+export default function HomeRoute(): JSX.Element {
+  return (
+    <AbstraxionProvider config={config}>
+      <HomeScreen />
+    </AbstraxionProvider>
+  );
+}
 
 type ManageStatus = "idle" | "pending" | "success" | "cancelled" | "error";
 
@@ -23,7 +43,7 @@ type ManageStatus = "idle" | "pending" | "success" | "cancelled" | "error";
  * need a WebView transport — tracked as Phase 9b). Manage-authenticators
  * piggy-backs on the same redirect flow via Expo WebBrowser.
  */
-export default function HomeScreen(): JSX.Element {
+function HomeScreen(): JSX.Element {
   const {
     data: account,
     login,
@@ -72,7 +92,13 @@ export default function HomeScreen(): JSX.Element {
       style={styles.scrollView}
     >
       <Text style={styles.title}>ABSTRAXION</Text>
-      <Text style={styles.subtitle}>React Native demo</Text>
+      <Text style={styles.subtitle}>React Native demo · Redirect mode</Text>
+
+      <Link href="/embedded" asChild>
+        <Pressable style={styles.linkRow}>
+          <Text style={styles.linkText}>Try embedded WebView mode →</Text>
+        </Pressable>
+      </Link>
 
       {isInitializing && (
         <View style={styles.loadingRow}>
@@ -303,5 +329,12 @@ const styles = StyleSheet.create({
   error: {
     color: "#f87171",
     fontSize: 12,
+  },
+  linkRow: {
+    paddingVertical: 6,
+  },
+  linkText: {
+    color: "#60a5fa",
+    fontSize: 13,
   },
 });

--- a/demos/react/src/pages/EmbeddedModePage.tsx
+++ b/demos/react/src/pages/EmbeddedModePage.tsx
@@ -65,7 +65,7 @@ function EmbeddedContent(): JSX.Element {
           disconnectedView="fullview"
           connectedView="visible"
           approvalView="inline"
-          className="w-full overflow-hidden rounded-2xl border border-white/10 bg-white"
+          className="w-[min(500px,calc(100vw-2rem))] overflow-hidden rounded-2xl border border-white/10 bg-white"
           style={{ height: 600 }}
         />
       ) : (

--- a/demos/svelte/src/lib/abstraxion.ts
+++ b/demos/svelte/src/lib/abstraxion.ts
@@ -1,245 +1,25 @@
 /**
- * ⚠️ TO BE PROMOTED — `createAbstraxionRuntime` and the helpers it returns
- * (`createReadClient`, `createDirectSigningClient`, `manageAuthenticators`,
- * etc.) are framework-agnostic and belong in `@burnt-labs/abstraxion-js`
- * itself. They live here for now so the demo PR stays self-contained;
- * tracked as Phase 9c in `.docs/tasks/abstraxion_package_restructure.md`.
+ * Svelte binding for `@burnt-labs/abstraxion-js`.
  *
- * Once promoted:
- *   - `abstraxion-react`'s `AbstraxionProvider` + hooks consume the same
- *     runtime, removing duplicated controller-narrowing logic.
- *   - This file shrinks to just the Svelte binding (`createAbstraxionStore`).
+ * The framework-agnostic runtime (`createAbstraxionRuntime`) lives in
+ * `@burnt-labs/abstraxion-js`. This file is the
+ * Svelte binding: a `writable` mirror of `runtime.subscribe` plus a
+ * `derived` shape that matches what `useAbstraxionAccount()` returns in React.
  *
- * --
- *
- * Reusable wrapper around `@burnt-labs/abstraxion-js` for non-React stacks.
- *
- * Two layers:
- *
- *   1. `createAbstraxionRuntime(config)` — framework-agnostic. Returns a
- *      controller, a `subscribe(cb)` you can wire into any reactivity system
- *      (Svelte stores, Vue refs, Solid signals, RxJS, plain callbacks…), plus
- *      ready-to-call helpers for direct signing and manage-authenticators.
- *
- *   2. `createAbstraxionStore(config)` — Svelte binding. Mirrors the runtime
- *      state into a Svelte `writable`, exposes a `derived` shape that matches
- *      what `useAbstraxionAccount()` returns in React.
- *
- * The runtime is the part you copy when porting to Vue/Solid/etc. — only the
- * `subscribe → reactive` step changes per framework.
+ * Port to Vue/Solid/vanilla by replacing `writable`/`derived` with the
+ * framework's reactivity primitive — the runtime stays the same.
  */
 import { writable, derived, type Readable } from "svelte/store";
 import {
-  AAClient,
   AccountStateGuards,
-  AUTHENTICATOR_TYPE,
-  BrowserRedirectStrategy,
-  BrowserStorageStrategy,
   CosmWasmClient,
-  GasPrice,
-  IframeController,
-  PopupController,
-  RedirectController,
-  RequireSigningClient,
-  SignerController,
-  createController,
-  createSignerFromSigningFunction,
-  normalizeAbstraxionConfig,
+  createAbstraxionRuntime,
   type AbstraxionConfig,
+  type AbstraxionRuntime,
+  type AbstraxionRuntimeOptions,
   type AccountState,
-  type AuthenticatorType,
-  type Controller,
-  type NormalizedAbstraxionConfig,
-  type RedirectStrategy,
   type SigningClient,
-  type StorageStrategy,
-  type Unsubscribe,
 } from "@burnt-labs/abstraxion-js";
-
-// ─── Framework-agnostic runtime ────────────────────────────────────────────
-
-export interface AbstraxionRuntimeOptions {
-  /**
-   * Override the default browser strategies. Useful for tests, SSR (provide
-   * no-op strategies), or non-browser hosts (Tauri, Electron, etc.).
-   */
-  strategies?: {
-    storageStrategy?: StorageStrategy;
-    redirectStrategy?: RedirectStrategy;
-  };
-  /**
-   * If `false`, the runtime won't call `controller.initialize()` for you —
-   * subscribe first, then call `runtime.initialize()` yourself. Defaults to
-   * `true`, which matches `<AbstraxionProvider>`'s React behavior.
-   */
-  autoInitialize?: boolean;
-}
-
-export interface AbstraxionRuntime {
-  /** The underlying controller — escape hatch for advanced flows (iframe.setContainerElement, etc.). */
-  controller: Controller;
-  /** Normalized config (defaults filled in from chainId). */
-  config: NormalizedAbstraxionConfig;
-  /** Current state snapshot. */
-  getState(): AccountState;
-  /** Subscribe to state changes. Returns an unsubscribe. */
-  subscribe(cb: (state: AccountState) => void): Unsubscribe;
-  /** Restore session, detect redirect callback, etc. Idempotent-ish — call once. */
-  initialize(): Promise<void>;
-  /** Start the auth flow. */
-  login(): Promise<void>;
-  /** Disconnect and clear stored grants. */
-  logout(): Promise<void>;
-  /** True for popup, redirect, embedded modes. */
-  isManageAuthSupported: boolean;
-  /** Open the manage-authenticators flow. Throws when not supported. */
-  manageAuthenticators(granterAddress: string): Promise<void>;
-  /**
-   * Read-only `CosmWasmClient` connected to the configured RPC. Same thing
-   * `useAbstraxionClient()` returns in React — internally just calls
-   * `CosmWasmClient.connect(rpcUrl)`. Cache the resolved client; don't call
-   * this on every render.
-   */
-  createReadClient(): Promise<CosmWasmClient>;
-  /**
-   * Build a direct-signing client (`requireAuth: true` equivalent). Resolves
-   * to:
-   *  - `RequireSigningClient` for popup / redirect / embedded modes (the
-   *    dashboard mediates approval over the active transport).
-   *  - `AAClient` for signer mode (the user-supplied signer signs each tx
-   *    directly — no dashboard involvement).
-   *
-   * Throws if called in signer mode before login (because `AAClient`
-   * construction needs the connected `granterAddress` and the
-   * `connectionInfo.signMessage` exposed by `SignerController`).
-   */
-  createDirectSigningClient(): Promise<SigningClient | undefined>;
-}
-
-export function createAbstraxionRuntime(
-  config: AbstraxionConfig,
-  options: AbstraxionRuntimeOptions = {},
-): AbstraxionRuntime {
-  const normalized = normalizeAbstraxionConfig(config);
-
-  const controller = createController(normalized, {
-    storageStrategy:
-      options.strategies?.storageStrategy ?? new BrowserStorageStrategy(),
-    redirectStrategy:
-      options.strategies?.redirectStrategy ?? new BrowserRedirectStrategy(),
-  });
-
-  const isManageAuthSupported =
-    controller instanceof PopupController ||
-    controller instanceof IframeController ||
-    controller instanceof RedirectController;
-
-  let initialized = false;
-
-  const runtime: AbstraxionRuntime = {
-    controller,
-    config: normalized,
-    getState: () => controller.getState(),
-    subscribe: (cb) => controller.subscribe(cb),
-    initialize: async () => {
-      if (initialized) return;
-      initialized = true;
-      await controller.initialize();
-    },
-    login: () => controller.connect(),
-    logout: () => controller.disconnect(),
-    isManageAuthSupported,
-    manageAuthenticators: async (granterAddress) => {
-      if (
-        controller instanceof PopupController ||
-        controller instanceof IframeController ||
-        controller instanceof RedirectController
-      ) {
-        return controller.promptManageAuthenticators(granterAddress);
-      }
-      throw new Error(
-        "manageAuthenticators is only supported in popup, redirect, and embedded modes.",
-      );
-    },
-    createReadClient: () => CosmWasmClient.connect(normalized.rpcUrl),
-    createDirectSigningClient: async () => {
-      // Popup / redirect / embedded: thin wrapper over the controller's
-      // existing `promptSignAndBroadcast` / `signAndBroadcastWithMetaAccount`
-      // method. Construction is sync; we await for API uniformity only.
-      if (controller instanceof PopupController) {
-        return new RequireSigningClient(
-          controller.promptSignAndBroadcast.bind(controller),
-          normalized.rpcUrl,
-        );
-      }
-      if (controller instanceof RedirectController) {
-        return new RequireSigningClient(
-          controller.promptSignAndBroadcast.bind(controller),
-          normalized.rpcUrl,
-        );
-      }
-      if (controller instanceof IframeController) {
-        return new RequireSigningClient(
-          controller.signAndBroadcastWithMetaAccount.bind(controller),
-          normalized.rpcUrl,
-        );
-      }
-
-      // Signer mode: build an AAClient from the connection info. Mirrors what
-      // useAbstraxionSigningClient does in @burnt-labs/abstraxion-react —
-      // this is the wiring you'd otherwise have to copy-paste.
-      if (controller instanceof SignerController) {
-        const state = controller.getState();
-        if (!AccountStateGuards.isConnected(state)) {
-          throw new Error(
-            "createDirectSigningClient(): user is not connected. Call login() first.",
-          );
-        }
-        const connectionInfo = controller.getConnectionInfo?.();
-        if (!connectionInfo) {
-          throw new Error(
-            "createDirectSigningClient(): SignerController has no connectionInfo — login may have failed.",
-          );
-        }
-        const authenticatorType = connectionInfo.metadata?.authenticatorType as
-          | AuthenticatorType
-          | undefined;
-        const authenticatorIndex =
-          (connectionInfo.metadata?.authenticatorIndex as number | undefined) ??
-          0;
-        if (
-          !authenticatorType ||
-          !Object.values(AUTHENTICATOR_TYPE).includes(authenticatorType)
-        ) {
-          throw new Error(
-            `createDirectSigningClient(): connectionInfo.metadata.authenticatorType is missing or invalid (got: ${String(authenticatorType)}).`,
-          );
-        }
-        const signer = createSignerFromSigningFunction({
-          smartAccountAddress: state.account.granterAddress,
-          authenticatorIndex,
-          authenticatorType,
-          signMessage: connectionInfo.signMessage,
-        });
-        return AAClient.connectWithSigner(normalized.rpcUrl, signer, {
-          gasPrice: GasPrice.fromString(normalized.gasPrice),
-        });
-      }
-
-      return undefined;
-    },
-  };
-
-  if (options.autoInitialize !== false) {
-    runtime.initialize().catch((error) => {
-      console.error("[abstraxion-runtime] initialize() failed:", error);
-    });
-  }
-
-  return runtime;
-}
-
-// ─── Svelte binding ────────────────────────────────────────────────────────
 
 export interface AbstraxionStoreValue {
   state: AccountState;
@@ -311,11 +91,12 @@ export function createAbstraxionStore(
   return {
     store,
     runtime,
-    login: runtime.login,
-    logout: runtime.logout,
-    manageAuthenticators: runtime.manageAuthenticators,
+    login: () => runtime.login(),
+    logout: () => runtime.logout(),
+    manageAuthenticators: (granterAddress: string) =>
+      runtime.manageAuthenticators(granterAddress),
     isManageAuthSupported: runtime.isManageAuthSupported,
-    createReadClient: runtime.createReadClient,
-    createDirectSigningClient: runtime.createDirectSigningClient,
+    createReadClient: () => runtime.createReadClient(),
+    createDirectSigningClient: () => runtime.createDirectSigningClient(),
   };
 }

--- a/packages/abstraxion-js/src/controllers/IframeController.ts
+++ b/packages/abstraxion-js/src/controllers/IframeController.ts
@@ -2,9 +2,10 @@
  * Iframe Controller
  * Inline iframe-based authentication flow
  *
- * Renders the full dashboard app inside an inline iframe. The dApp controls
- * where and how big the iframe is via a container element. Authentication
- * and grant approval happen inside the iframe UI.
+ * Renders the full dashboard app inside an inline iframe (web) or WebView
+ * (React Native). Mount + transport details are delegated to a host-supplied
+ * `IframeTransportStrategy`, so this controller has no direct DOM or
+ * react-native-webview dependency.
  *
  * Communication uses MessageChannelManager for request-response (CONNECT,
  * SIGN_AND_BROADCAST) — each request gets its own isolated MessageChannel
@@ -12,29 +13,13 @@
  *
  * Two disconnect types exist:
  * - DISCONNECT (soft): SDK detaches the iframe without notifying the dashboard.
- *   Dashboard session survives. Not currently sent but defined for future use
- *   (e.g. ITP storage cleanup, UI hints).
- * - HARD_DISCONNECT: Full session clear on both sides. Sent as a raw postMessage
- *   in both directions (SDK → dashboard and dashboard → SDK). Currently only the
- *   dashboard → SDK direction is active (user clicks disconnect inside the iframe).
- *   The SDK → dashboard direction is defined for future use.
- *
- * The iframe handles:
- * - User authentication (Stytch OAuth, Passkey, MetaMask, Keplr, etc.)
- * - Grant permission UI
- *
- * The SDK (this controller) handles:
- * - Iframe lifecycle management
- * - Local session keypair generation (via AbstraxionAuth)
- * - GranteeSignerClient creation
- * - MessageChannel-based CONNECT / SIGN_AND_BROADCAST
- * - IFRAME_READY handshake (waits for dashboard to mount before sending requests)
- * - Session restoration with on-chain grant verification (via orchestrator)
+ *   Dashboard session survives. Not currently sent but defined for future use.
+ * - HARD_DISCONNECT: Full session clear on both sides. The dashboard → SDK
+ *   direction is delivered as a push event via `IframeTransportStrategy.onPushMessage`.
  */
 
 import {
   AbstraxionAuth,
-  MessageChannelManager,
   GranteeSignerClient,
   TypedEventEmitter,
 } from "@burnt-labs/abstraxion-core";
@@ -73,6 +58,8 @@ import type {
   IframeAuthentication,
   NormalizedAbstraxionConfig,
 } from "../types";
+import { BrowserIframeTransportStrategy } from "../strategies/BrowserIframeTransportStrategy";
+import type { IframeTransportStrategy } from "../strategies/IframeTransportStrategy";
 
 /**
  * Configuration for IframeController
@@ -101,6 +88,12 @@ export interface IframeControllerConfig {
   storageStrategy: StorageStrategy;
   /** Redirect strategy (required by AbstraxionAuth, not used for actual redirects) */
   redirectStrategy: RedirectStrategy;
+  /**
+   * Iframe transport strategy. Optional — defaults to `BrowserIframeTransportStrategy`
+   * for back-compat with web consumers and existing tests. React Native callers MUST
+   * pass an `RNWebViewIframeTransport`.
+   */
+  iframeTransportStrategy?: IframeTransportStrategy;
 }
 
 /**
@@ -112,9 +105,7 @@ export class IframeController extends BaseController {
   private abstraxionAuth: AbstraxionAuth;
   private orchestrator: ConnectionOrchestrator;
   private initializePromise: Promise<void> | null = null;
-  private iframe: HTMLIFrameElement | null = null;
-  /** Handles all request-response communication with the iframe */
-  private messageManager: MessageChannelManager;
+  private transport: IframeTransportStrategy;
   private iframeOrigin: string;
   private granterAddress: string | null = null;
   private granteeWallet: SignArbSecp256k1HdWallet | null = null;
@@ -123,8 +114,7 @@ export class IframeController extends BaseController {
   private eventEmitter = new TypedEventEmitter<
     IframeSDKEvents & Record<string, unknown>
   >();
-  private disconnectListener: ((event: MessageEvent) => void) | null = null;
-  private iframeReadyListener: ((event: MessageEvent) => void) | null = null;
+  private unsubscribePushMessages: (() => void) | null = null;
 
   // Transient UI state: true while a requireAuth signing request is pending
   // and the iframe needs to be visible for user approval.
@@ -140,6 +130,7 @@ export class IframeController extends BaseController {
     config: NormalizedAbstraxionConfig,
     storageStrategy: StorageStrategy,
     redirectStrategy: RedirectStrategy,
+    iframeTransportStrategy?: IframeTransportStrategy,
   ): IframeController {
     if (config.authentication?.type !== "embedded") {
       throw new Error(
@@ -158,6 +149,7 @@ export class IframeController extends BaseController {
       contracts: config.contracts,
       storageStrategy,
       redirectStrategy,
+      iframeTransportStrategy,
     };
 
     return new IframeController(iframeConfig);
@@ -166,7 +158,6 @@ export class IframeController extends BaseController {
   constructor(config: IframeControllerConfig) {
     super({ status: "initializing" });
     this.config = config;
-    this.messageManager = new MessageChannelManager();
 
     // Extract and validate iframe origin
     if (!config.iframe.iframeUrl) {
@@ -181,6 +172,22 @@ export class IframeController extends BaseController {
     } catch {
       throw new Error("Invalid iframe URL in configuration");
     }
+
+    // Default to browser transport so the existing tests + web consumers
+    // continue to work without explicit injection. React Native consumers
+    // pass an RN WebView-backed transport.
+    this.transport =
+      config.iframeTransportStrategy ?? new BrowserIframeTransportStrategy();
+
+    // If an explicit container was passed (web only), bind it to the transport.
+    if (config.iframe.containerElement) {
+      this.transport.setContainer(config.iframe.containerElement);
+    }
+
+    // Subscribe to dashboard push messages (HARD_DISCONNECT etc.)
+    this.unsubscribePushMessages = this.transport.onPushMessage(
+      this.handlePushMessage.bind(this),
+    );
 
     // Create AbstraxionAuth for keypair/session management (same as Popup/Redirect controllers)
     this.abstraxionAuth = new AbstraxionAuth(
@@ -225,6 +232,37 @@ export class IframeController extends BaseController {
   }
 
   /**
+   * Override the default transport strategy. Used by `createAbstraxionRuntime`
+   * so the runtime can inject a host-supplied transport without forcing every
+   * controller config to thread the strategy through manually.
+   *
+   * Replaces any previously bound transport — the old one is unmounted first.
+   */
+  setTransportStrategy(transport: IframeTransportStrategy): void {
+    if (transport === this.transport) return;
+
+    if (this.transport) {
+      this.unsubscribePushMessages?.();
+      this.unsubscribePushMessages = null;
+      this.transport.unmount();
+    }
+    this.transport = transport;
+
+    if (this.config.iframe.containerElement) {
+      this.transport.setContainer(this.config.iframe.containerElement);
+    }
+
+    this.unsubscribePushMessages = this.transport.onPushMessage(
+      this.handlePushMessage.bind(this),
+    );
+  }
+
+  /** Returns the active transport strategy. Mainly useful for tests/embedded UI hosts. */
+  getTransportStrategy(): IframeTransportStrategy {
+    return this.transport;
+  }
+
+  /**
    * Subscribe to iframe SDK events
    */
   on<K extends keyof IframeSDKEvents>(
@@ -246,10 +284,7 @@ export class IframeController extends BaseController {
 
   /**
    * Initialize: attempt to restore a prior session from storage.
-   * Uses orchestrator.restoreSession() — same pattern as Redirect/Signer/Popup controllers.
-   * Verifies grants on-chain before restoring session.
-   * Idempotent: returns the same promise if called while already initializing
-   * (guards against React strict-mode double-invocation)
+   * Idempotent: returns the same promise if called while already initializing.
    */
   async initialize(): Promise<void> {
     if (this.initializePromise) return this.initializePromise;
@@ -259,7 +294,6 @@ export class IframeController extends BaseController {
 
   private async doInitialize(): Promise<void> {
     try {
-      // Restore session via orchestrator (verifies grants on-chain, creates signing client)
       const restorationResult = await this.orchestrator.restoreSession(true);
 
       if (
@@ -268,7 +302,6 @@ export class IframeController extends BaseController {
       ) {
         const accountInfo = getAccountInfoFromRestored(restorationResult);
 
-        // Keep instance vars for public API (getAddress, getGranteeAddress, getSigningClient)
         this.granterAddress = accountInfo.granterAddress;
         this.granteeWallet = accountInfo.keypair;
         this.granteeAddress = accountInfo.granteeAddress;
@@ -281,8 +314,8 @@ export class IframeController extends BaseController {
         });
 
         // Try to mount the iframe showing the "Connected" view.
-        // containerElement may not be set yet (React ref timing),
-        // in which case setContainerElement() will handle it later.
+        // The transport may not have a container yet (React ref timing),
+        // in which case setContainerElement() will retry later.
         this.mountConnectedIframe();
         return;
       }
@@ -295,7 +328,6 @@ export class IframeController extends BaseController {
         return;
       }
 
-      // No session to restore — transition to idle
       this.dispatch({ type: "RESET" });
     } catch (error) {
       console.error("[IframeController] Initialization error:", error);
@@ -310,13 +342,13 @@ export class IframeController extends BaseController {
   }
 
   /**
-   * Connect using the inline iframe
+   * Connect using the inline iframe / WebView.
    *
-   * 1. Generates grantee keypair via AbstraxionAuth (needed for URL params)
-   * 2. Builds iframe URL with mode=inline and grant params
-   * 3. Creates/updates iframe element
-   * 4. Waits for IFRAME_READY (dashboard React app mounted)
-   * 5. Sends CONNECT via MessageChannelManager and waits for response
+   * 1. Generates grantee keypair via AbstraxionAuth (needed for URL params).
+   * 2. Builds iframe URL with mode=inline and grant params.
+   * 3. Mounts the iframe via the active `IframeTransportStrategy`.
+   * 4. Waits for IFRAME_READY (dashboard React app mounted).
+   * 5. Sends CONNECT and waits for response.
    */
   async connect(): Promise<void> {
     if (this.getState().status === "connected") {
@@ -327,36 +359,29 @@ export class IframeController extends BaseController {
     this.dispatch({ type: "START_CONNECT" });
 
     try {
-      // Generate keypair via AbstraxionAuth (same storage as other controllers)
       this.granteeWallet =
         await this.abstraxionAuth.generateAndStoreTempAccount();
       this.granteeAddress = await this.abstraxionAuth.getKeypairAddress();
 
-      // Build iframe URL with all params
       const iframeUrl = this.buildIframeUrl();
 
-      // Register the IFRAME_READY listener BEFORE creating/updating the iframe
-      // to eliminate the race where a fast-booting dashboard sends IFRAME_READY
-      // before the listener exists.
-      const readyPromise = this.waitForIframeReady();
+      // Register the IFRAME_READY listener BEFORE mounting to eliminate
+      // the race where a fast-booting dashboard sends IFRAME_READY before
+      // the listener exists.
+      const readyPromise = this.transport.waitForReady(30_000);
 
-      // Initialize iframe if not done, or update src
-      if (!this.iframe) {
-        this.initializeIframe(iframeUrl);
+      if (!this.transport.isMounted()) {
+        this.transport.mount({ url: iframeUrl, origin: this.iframeOrigin });
       } else {
-        this.iframe.src = iframeUrl;
+        this.transport.navigate(iframeUrl);
       }
 
-      // Wait for the dashboard's IframeMessageHandler to mount
       await readyPromise;
 
-      // Send CONNECT via MessageChannel — the dashboard's IframeMessageHandler
-      // returns a Promise that resolves when auth + grants complete
-      const response = await this.messageManager.sendRequest<
+      const response = await this.transport.sendRequest<
         ConnectPayload,
         ConnectResponse
       >(
-        this.iframe!,
         IframeMessageType.CONNECT,
         {
           grantParams: this.config.treasury
@@ -366,7 +391,6 @@ export class IframeController extends BaseController {
               }
             : undefined,
         },
-        this.iframeOrigin,
         300_000, // 5 min — user needs time for auth + grant approval
       );
 
@@ -385,30 +409,16 @@ export class IframeController extends BaseController {
   }
 
   /**
-   * Disconnect and cleanup (SDK-initiated / soft disconnect)
+   * Disconnect and cleanup (SDK-initiated / soft disconnect).
    *
-   * Only clears SDK-side state (grantee keypair, granter address) and removes
-   * the iframe from the DOM. Does NOT send a DISCONNECT message to the dashboard,
-   * so the dashboard session remains intact.
-   *
-   * This means on the next connect() call the user only needs to re-approve
-   * grants — they won't have to fully re-authenticate with their XION account.
-   *
-   * Contrast with iframe-initiated disconnect (user clicks Disconnect inside the
-   * iframe): that path goes through AuthStateManager.logout() in the dashboard
-   * and is a full logout, which is the correct behaviour for a user deliberately
-   * signing out of their account.
+   * Removes the iframe silently — the dashboard session survives so the user
+   * only needs to re-approve grants on the next connect() call, not fully
+   * re-authenticate.
    */
   async disconnect(): Promise<void> {
-    // Remove the iframe silently — the dashboard session survives.
-    // connect() will create a fresh iframe whose dashboard app can reuse
-    // the existing session from storage.
-    if (this.iframe) {
-      this.removeIframe();
+    if (this.transport.isMounted()) {
+      this.transport.unmount();
     }
-
-    // Clear SDK-side state (keypair, granter, signing client) and dispatch
-    // EXPLICITLY_DISCONNECTED so the embed does not immediately re-trigger login.
     await this.handleDisconnect();
   }
 
@@ -417,40 +427,34 @@ export class IframeController extends BaseController {
    * Typically called from a React ref callback. If a session was already
    * restored before the container was available, the iframe will be mounted immediately.
    */
-  setContainerElement(element: HTMLElement): void {
-    this.config.iframe = { ...this.config.iframe, containerElement: element };
+  setContainerElement(element: unknown): void {
+    this.config.iframe = {
+      ...this.config.iframe,
+      containerElement: element as HTMLElement,
+    };
+    this.transport.setContainer(element);
 
-    // If session was restored before the container was available, mount now
-    if (this.getState().status === "connected" && !this.iframe) {
+    if (this.getState().status === "connected" && !this.transport.isMounted()) {
       this.mountConnectedIframe();
     }
   }
 
-  /**
-   * Whether a container element has been set via setContainerElement().
-   * Used by AbstraxionProvider to warn if <AbstraxionEmbed> is missing.
-   */
+  /** Whether a container element has been set via setContainerElement(). */
   hasContainerElement(): boolean {
-    return !!this.config.iframe.containerElement;
+    return this.transport.hasContainer();
   }
 
-  /**
-   * Get the current user's address
-   */
+  /** Get the current user's address. */
   getAddress(): string | null {
     return this.granterAddress;
   }
 
-  /**
-   * Get the signing client
-   */
+  /** Get the signing client. */
   getSigningClient(): GranteeSignerClient | null {
     return this.signingClient;
   }
 
-  /**
-   * Get the grantee address (session key address)
-   */
+  /** Get the grantee address (session key address). */
   getGranteeAddress(): string | null {
     return this.granteeAddress;
   }
@@ -477,15 +481,12 @@ export class IframeController extends BaseController {
   private setAwaitingApproval(value: boolean): void {
     if (this._awaitingApproval !== value) {
       this._awaitingApproval = value;
+      this.transport.setVisible(value);
       this._approvalListeners.forEach((cb) => cb(value));
     }
   }
 
-  /**
-   * Cancel a pending approval (signing request).
-   * Rejects the in-flight signAndBroadcastWithMetaAccount promise with a
-   * cancellation error and hides the approval UI.
-   */
+  /** Cancel a pending approval (signing request). */
   cancelApproval(): void {
     if (this._cancelPendingApproval) {
       this._cancelPendingApproval();
@@ -496,9 +497,6 @@ export class IframeController extends BaseController {
 
   /**
    * Sign and broadcast a transaction with the user's direct authenticator (meta-account).
-   *
-   * Sends SIGN_AND_BROADCAST via MessageChannelManager to the dashboard iframe,
-   * which shows a signing approval UI and broadcasts the transaction.
    */
   async signAndBroadcastWithMetaAccount(
     signerAddress: string,
@@ -506,16 +504,12 @@ export class IframeController extends BaseController {
     fee: StdFee | "auto" | number,
     memo?: string,
   ): Promise<SignAndBroadcastResult> {
-    if (!this.iframe?.contentWindow) {
+    if (!this.transport.isMounted()) {
       throw new Error(
         "Iframe is not available. Ensure the iframe is mounted and the user is connected.",
       );
     }
 
-    // Validate payload before sending — catches common dev mistakes early.
-    // The casts below are needed because CosmJS types (readonly EncodeObject[],
-    // StdFee | "auto" | number) don't perfectly overlap with TxTransportPayload's
-    // field types at the TS level, but are structurally compatible at runtime.
     const txPayloadObj: TxTransportPayload = {
       messages: messages as TxTransportPayload["messages"],
       fee: fee as TxTransportPayload["fee"],
@@ -525,14 +519,12 @@ export class IframeController extends BaseController {
 
     this.setAwaitingApproval(true);
     try {
-      // Race the MessageChannel request against a cancellation promise so
-      // that cancelApproval() can abort the flow from the UI side.
       const response = await new Promise<{ signedTx: SignAndBroadcastResult }>(
         (resolve, reject) => {
           this._cancelPendingApproval = () =>
             reject(new Error("User cancelled signing request"));
 
-          this.messageManager
+          this.transport
             .sendRequest<
               {
                 transaction: {
@@ -544,11 +536,9 @@ export class IframeController extends BaseController {
               },
               { signedTx: SignAndBroadcastResult }
             >(
-              this.iframe!,
               IframeMessageType.SIGN_AND_BROADCAST,
               { transaction: { messages, fee, memo }, signerAddress },
-              this.iframeOrigin,
-              300_000, // 5 min — user needs time to review and approve
+              300_000,
             )
             .then(resolve, reject);
         },
@@ -562,17 +552,13 @@ export class IframeController extends BaseController {
   }
 
   /**
-   * Add an authenticator to the user's account via the embedded iframe.
-   *
-   * Sends MANAGE_AUTHENTICATORS via MessageChannelManager to the dashboard iframe,
-   * which shows an add-authenticator UI and resolves when the user completes
-   * or cancels. Same pattern as signAndBroadcastWithMetaAccount.
+   * Add or remove an authenticator on the user's account via the embedded
+   * iframe. Mirrors the popup/redirect manage-authenticators surface.
    */
-  // _signerAddress is unused here because the iframe already knows the connected
-  // account. The parameter exists for interface symmetry with PopupController and
-  // RedirectController so callers can use promptManageAuthenticators uniformly.
+  // _signerAddress is unused: the iframe already knows the connected account.
+  // The parameter exists for symmetry with PopupController/RedirectController.
   async promptManageAuthenticators(_signerAddress: string): Promise<void> {
-    if (!this.iframe?.contentWindow) {
+    if (!this.transport.isMounted()) {
       throw new Error(
         "Iframe is not available. Ensure the iframe is mounted and the user is connected.",
       );
@@ -584,17 +570,11 @@ export class IframeController extends BaseController {
         this._cancelPendingApproval = () =>
           reject(new Error("User cancelled manage authenticators request"));
 
-        this.messageManager
+        this.transport
           .sendRequest<
             ManageAuthenticatorsPayload,
             ManageAuthenticatorsResponse
-          >(
-            this.iframe!,
-            IframeMessageType.MANAGE_AUTHENTICATORS,
-            {},
-            this.iframeOrigin,
-            600_000, // 10 min — user needs time to manage authenticators
-          )
+          >(IframeMessageType.MANAGE_AUTHENTICATORS, {}, 600_000)
           .then(resolve, reject);
       });
     } finally {
@@ -603,51 +583,14 @@ export class IframeController extends BaseController {
     }
   }
 
-  /**
-   * Cleanup resources
-   */
+  /** Cleanup resources. */
   destroy(): void {
-    // Remove disconnect listener
-    if (this.disconnectListener) {
-      window.removeEventListener("message", this.disconnectListener);
-      this.disconnectListener = null;
-    }
-
-    // Remove IFRAME_READY listener
-    if (this.iframeReadyListener) {
-      window.removeEventListener("message", this.iframeReadyListener);
-      this.iframeReadyListener = null;
-    }
-
-    // Remove iframe from DOM
-    if (this.iframe && this.iframe.parentNode) {
-      this.iframe.parentNode.removeChild(this.iframe);
-    }
-    this.iframe = null;
-
-    // Clear event listeners
+    this.unsubscribePushMessages?.();
+    this.unsubscribePushMessages = null;
+    this.transport.unmount();
     this.eventEmitter.removeAllListeners();
-
-    // Cleanup orchestrator
     this.orchestrator.destroy();
-
     super.destroy();
-  }
-
-  /**
-   * Remove the iframe from DOM and clean up its event listener.
-   * Used during SDK-initiated disconnect to prevent a visible re-render
-   * before connect() creates a fresh iframe.
-   */
-  private removeIframe(): void {
-    if (this.disconnectListener) {
-      window.removeEventListener("message", this.disconnectListener);
-      this.disconnectListener = null;
-    }
-    if (this.iframe?.parentNode) {
-      this.iframe.parentNode.removeChild(this.iframe);
-    }
-    this.iframe = null;
   }
 
   // ─── Private helpers ────────────────────────────────────────────────────────
@@ -655,31 +598,32 @@ export class IframeController extends BaseController {
   /**
    * Mount the iframe showing the dashboard's "Connected" view.
    * Used after restoring a session from storage on page refresh.
-   * Only sets mode=inline (no grantee/treasury — grant is already done).
    */
   private mountConnectedIframe(): void {
-    if (!this.config.iframe.containerElement) {
-      return; // Container not available yet — setContainerElement() will retry
+    if (!this.transport.hasContainer()) {
+      return;
     }
-    if (this.iframe) {
-      return; // Already mounted
+    if (this.transport.isMounted()) {
+      return;
     }
 
     const url = new URL(this.config.iframe.iframeUrl!);
     url.searchParams.set("mode", "inline");
-    url.searchParams.set("redirect_uri", window.location.origin);
-    this.initializeIframe(url.toString());
+    if (typeof window !== "undefined") {
+      url.searchParams.set("redirect_uri", window.location.origin);
+    }
+    this.transport.mount({ url: url.toString(), origin: this.iframeOrigin });
   }
 
-  /**
-   * Build the iframe URL with all required query params
-   */
+  /** Build the iframe URL with all required query params. */
   private buildIframeUrl(): string {
     const url = new URL(this.config.iframe.iframeUrl!);
 
     url.searchParams.set("mode", "inline");
     url.searchParams.set("grantee", this.granteeAddress!);
-    url.searchParams.set("redirect_uri", window.location.origin);
+    if (typeof window !== "undefined") {
+      url.searchParams.set("redirect_uri", window.location.origin);
+    }
 
     if (this.config.treasury) {
       url.searchParams.set("treasury", this.config.treasury);
@@ -698,94 +642,37 @@ export class IframeController extends BaseController {
   }
 
   /**
-   * Wait for the iframe's IframeMessageHandler to mount.
-   * The dashboard sends IFRAME_READY via postMessage once it's ready
-   * to accept MessageChannel requests.
+   * Handle push events from the dashboard (HARD_DISCONNECT etc.).
+   * Routed through the active transport strategy.
    */
-  private waitForIframeReady(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        cleanup();
-        reject(new Error("Iframe did not become ready within 30s"));
-      }, 30_000);
+  private handlePushMessage(data: unknown): void {
+    const event = data as { type?: string } | undefined;
+    if (!event || typeof event.type !== "string") return;
 
-      const handler = (event: MessageEvent) => {
-        if (event.origin !== this.iframeOrigin) return;
-        if (event.data?.type === DashboardMessageType.IFRAME_READY) {
-          cleanup();
-          resolve();
-        }
-      };
-
-      const cleanup = () => {
-        window.removeEventListener("message", handler);
-        this.iframeReadyListener = null;
-        clearTimeout(timeout);
-      };
-
-      this.iframeReadyListener = handler;
-      window.addEventListener("message", handler);
-    });
-  }
-
-  /**
-   * Initialize the iframe element and mount it to the container
-   */
-  private initializeIframe(src: string): void {
-    const container = this.config.iframe.containerElement;
-    if (!container) {
-      throw new Error(
-        "containerElement is required for iframe mode. " +
-          "Provide a DOM element where the iframe should be mounted.",
-      );
-    }
-
-    const iframe = document.createElement("iframe");
-    iframe.src = src;
-    iframe.style.width = "100%";
-    iframe.style.height = "100%";
-    iframe.style.border = "none";
-    iframe.allow = `publickey-credentials-get ${this.iframeOrigin}; clipboard-read; clipboard-write`;
-
-    container.appendChild(iframe);
-    this.iframe = iframe;
-
-    // Listen for HARD_DISCONNECT from the dashboard (user clicked disconnect inside
-    // the iframe UI — full session clear on both sides).
-    this.disconnectListener = (event: MessageEvent) => {
-      if (event.origin !== this.iframeOrigin) return;
-      if (event.data?.type === DashboardMessageType.HARD_DISCONNECT) {
-        if (this.getState().status === "connected") {
-          this.removeIframe();
-          this.handleDisconnect().catch((error) => {
-            console.error(
-              "[IframeController] Error handling hard disconnect:",
-              error,
-            );
-          });
-        }
+    if (event.type === DashboardMessageType.HARD_DISCONNECT) {
+      if (this.getState().status === "connected") {
+        this.transport.unmount();
+        this.handleDisconnect().catch((error) => {
+          console.error(
+            "[IframeController] Error handling hard disconnect:",
+            error,
+          );
+        });
       }
-    };
-    window.addEventListener("message", this.disconnectListener);
+    }
   }
 
   /**
-   * Complete connection after receiving address from MessageChannel CONNECT response
-   * Stores granter via AbstraxionAuth and creates GranteeSignerClient (same as Popup/Redirect)
+   * Complete connection after receiving address from MessageChannel CONNECT response.
    */
   private async completeConnection(granterAddress: string): Promise<void> {
     this.granterAddress = granterAddress;
 
-    // Store granter via AbstraxionAuth (same storage key as other controllers)
     await this.abstraxionAuth.setGranter(granterAddress);
-
-    // Sync in-memory state for getSigner()
     this.abstraxionAuth.abstractAccount = this.granteeWallet!;
 
-    // Emit authenticated event
     this.eventEmitter.emit("authenticated", { address: granterAddress });
 
-    // Create signing client via AbstraxionAuth
     const signingClient = await this.abstraxionAuth.getSigner(
       GasPrice.fromString(this.config.gasPrice),
     );
@@ -804,11 +691,8 @@ export class IframeController extends BaseController {
     });
   }
 
-  /**
-   * Handle disconnect — shared between SDK-initiated and iframe-initiated
-   */
+  /** Handle disconnect — shared between SDK-initiated and iframe-initiated. */
   private async handleDisconnect(): Promise<void> {
-    // Clear session via AbstraxionAuth (same storage keys as other controllers)
     try {
       await this.abstraxionAuth.logout();
     } catch (error) {
@@ -818,17 +702,12 @@ export class IframeController extends BaseController {
       );
     }
 
-    // Clear local state
     this.granterAddress = null;
     this.granteeWallet = null;
     this.granteeAddress = null;
     this.signingClient = null;
 
-    // Emit disconnected event
     this.eventEmitter.emit("disconnected", {});
-
-    // Mark as explicitly disconnected so the embed does not re-trigger login
-    // on the next render within the same page session.
     this.dispatch({ type: "EXPLICITLY_DISCONNECTED" });
   }
 }

--- a/packages/abstraxion-js/src/controllers/factory.ts
+++ b/packages/abstraxion-js/src/controllers/factory.ts
@@ -21,7 +21,11 @@ import type { ControllerStrategies } from "./types";
  */
 export function createController(
   config: NormalizedAbstraxionConfig,
-  { storageStrategy, redirectStrategy }: ControllerStrategies,
+  {
+    storageStrategy,
+    redirectStrategy,
+    iframeTransportStrategy,
+  }: ControllerStrategies,
 ): Controller {
   const authMode = config.authentication?.type || "redirect";
 
@@ -71,6 +75,7 @@ export function createController(
       config,
       storageStrategy,
       redirectStrategy,
+      iframeTransportStrategy,
     );
   } else {
     throw new Error(`Unknown authentication mode: ${authMode}`);

--- a/packages/abstraxion-js/src/controllers/types.ts
+++ b/packages/abstraxion-js/src/controllers/types.ts
@@ -13,6 +13,7 @@ import type {
   StorageStrategy,
 } from "@burnt-labs/abstraxion-core";
 import type { NormalizedAbstraxionConfig } from "../types";
+import type { IframeTransportStrategy } from "../strategies/IframeTransportStrategy";
 
 /**
  * State subscription callback
@@ -102,6 +103,12 @@ export interface ControllerStrategies {
   storageStrategy: StorageStrategy;
   /** Redirect strategy (web: window.location, React Native: deep linking, etc.) */
   redirectStrategy: RedirectStrategy;
+  /**
+   * Iframe transport strategy. Required when `authentication.type === "embedded"`.
+   * Web hosts use `BrowserIframeTransportStrategy`; React Native hosts use
+   * `RNWebViewIframeTransport` from `@burnt-labs/abstraxion-react-native`.
+   */
+  iframeTransportStrategy?: IframeTransportStrategy;
 }
 
 /**

--- a/packages/abstraxion-js/src/index.ts
+++ b/packages/abstraxion-js/src/index.ts
@@ -40,7 +40,19 @@ export type {
   Unsubscribe,
 } from "./controllers";
 
-export { BrowserRedirectStrategy, BrowserStorageStrategy } from "./strategies";
+export { BrowserIframeTransportStrategy } from "./strategies/BrowserIframeTransportStrategy";
+export { BrowserRedirectStrategy } from "./strategies/BrowserRedirectStrategy";
+export { BrowserStorageStrategy } from "./strategies/BrowserStorageStrategy";
+export type {
+  IframeMountContext,
+  IframeTransportStrategy,
+} from "./strategies/IframeTransportStrategy";
+
+export { createAbstraxionRuntime } from "./runtime";
+export type {
+  AbstraxionRuntime,
+  AbstraxionRuntimeOptions,
+} from "./runtime";
 
 export {
   createAccountCreationConfigFromConfig,

--- a/packages/abstraxion-js/src/index.ts
+++ b/packages/abstraxion-js/src/index.ts
@@ -49,10 +49,7 @@ export type {
 } from "./strategies/IframeTransportStrategy";
 
 export { createAbstraxionRuntime } from "./runtime";
-export type {
-  AbstraxionRuntime,
-  AbstraxionRuntimeOptions,
-} from "./runtime";
+export type { AbstraxionRuntime, AbstraxionRuntimeOptions } from "./runtime";
 
 export {
   createAccountCreationConfigFromConfig,

--- a/packages/abstraxion-js/src/runtime.ts
+++ b/packages/abstraxion-js/src/runtime.ts
@@ -1,0 +1,346 @@
+/**
+ * Framework-agnostic runtime for `@burnt-labs/abstraxion-js`.
+ *
+ * `createAbstraxionRuntime(config, options)` is the single entry point every
+ * framework wrapper builds on. It owns:
+ *   - controller construction (singleton-friendly via `useRef`-style consumers)
+ *   - state subscription (`subscribe` + `getState`)
+ *   - login / logout
+ *   - read-client / direct-signing-client construction (covers all four modes)
+ *   - manage-authenticators dispatch
+ *   - iframe approval-state subscription (web embedded mode only)
+ *   - dynamic `getSignerConfig` updates (signer mode only)
+ *
+ * Frameworks (React/Svelte/Vue/Solid/vanilla) only need to mirror
+ * `runtime.subscribe(getState)` into their own reactivity primitive.
+ */
+
+import {
+  AAClient,
+  createSignerFromSigningFunction,
+  GasPrice,
+  AUTHENTICATOR_TYPE,
+  type AuthenticatorType,
+} from "@burnt-labs/signers";
+import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
+import {
+  AccountStateGuards,
+  type AccountState,
+} from "@burnt-labs/account-management";
+import type {
+  RedirectStrategy,
+  StorageStrategy,
+} from "@burnt-labs/abstraxion-core";
+
+import {
+  createController,
+  IframeController,
+  PopupController,
+  RedirectController,
+  SignerController,
+  RequireSigningClient,
+  type Controller,
+  type Unsubscribe,
+} from "./controllers";
+import { BrowserIframeTransportStrategy } from "./strategies/BrowserIframeTransportStrategy";
+import { BrowserRedirectStrategy } from "./strategies/BrowserRedirectStrategy";
+import { BrowserStorageStrategy } from "./strategies/BrowserStorageStrategy";
+import type { IframeTransportStrategy } from "./strategies/IframeTransportStrategy";
+import type {
+  AbstraxionConfig,
+  NormalizedAbstraxionConfig,
+  SigningClient,
+} from "./types";
+import { normalizeAbstraxionConfig } from "./utils/normalizeAbstraxionConfig";
+
+export interface AbstraxionRuntimeOptions {
+  /**
+   * Override the default browser strategies. React Native (and SSR / Tauri /
+   * Electron / tests) supplies its own here.
+   */
+  strategies?: {
+    storageStrategy?: StorageStrategy;
+    redirectStrategy?: RedirectStrategy;
+    iframeTransportStrategy?: IframeTransportStrategy;
+  };
+  /**
+   * If `false`, the runtime won't call `controller.initialize()` for you —
+   * subscribe first, then call `runtime.initialize()` yourself. Defaults to
+   * `true`, which matches `<AbstraxionProvider>`'s React behavior.
+   */
+  autoInitialize?: boolean;
+}
+
+export interface AbstraxionRuntime {
+  /** The underlying controller — escape hatch for advanced flows. */
+  controller: Controller;
+  /** Normalized config (defaults filled in from chainId). */
+  config: NormalizedAbstraxionConfig;
+  /** Active auth mode, derived from the controller instance. */
+  authMode: "signer" | "redirect" | "embedded" | "popup";
+  /** Current state snapshot. */
+  getState(): AccountState;
+  /** Subscribe to state changes. Returns an unsubscribe. */
+  subscribe(cb: (state: AccountState) => void): Unsubscribe;
+  /**
+   * Subscribe to "awaitingApproval" changes — only meaningful in embedded mode.
+   * In other modes the callback is registered but never fires.
+   */
+  subscribeApproval(cb: (value: boolean) => void): Unsubscribe;
+  /** Current approval-pending state. Always `false` outside embedded mode. */
+  getApprovalState(): boolean;
+  /** Restore session, detect redirect callback, etc. Idempotent — call once. */
+  initialize(): Promise<void>;
+  /** Start the auth flow. */
+  login(): Promise<void>;
+  /** Disconnect and clear stored grants. */
+  logout(): Promise<void>;
+  /** True for popup, redirect, embedded modes. */
+  isManageAuthSupported: boolean;
+  /**
+   * Human-readable reason for `isManageAuthSupported === false`. `undefined`
+   * when manage-auth is supported. Hooks surface this to consumers so disabled
+   * UI can explain itself.
+   */
+  manageAuthUnsupportedReason: string | undefined;
+  /** Open the manage-authenticators flow. Throws when not supported. */
+  manageAuthenticators(granterAddress: string): Promise<void>;
+  /**
+   * Read-only `CosmWasmClient` connected to the configured RPC. Construct
+   * this once and cache it; do not call on every render.
+   */
+  createReadClient(): Promise<CosmWasmClient>;
+  /**
+   * Build a direct-signing client (`requireAuth: true` equivalent). Resolves
+   * to:
+   *  - `RequireSigningClient` for popup / redirect / embedded modes (the
+   *    dashboard mediates approval over the active transport).
+   *  - `AAClient` for signer mode (the user-supplied signer signs each tx
+   *    directly — no dashboard involvement).
+   *
+   * Throws if called in signer mode before login.
+   */
+  createDirectSigningClient(): Promise<SigningClient | undefined>;
+  /**
+   * Update the dynamic `getSignerConfig` function used in signer mode.
+   * Common pattern: external auth providers (Turnkey/Privy) become ready
+   * after the initial render and need to swap in a new authenticated function.
+   *
+   * No-op outside signer mode.
+   */
+  updateGetSignerConfig(
+    fn: NonNullable<
+      import("./types").SignerAuthentication["getSignerConfig"]
+    >,
+  ): void;
+  /** Tear down listeners + iframe (delegates to `controller.destroy()`). */
+  destroy(): void;
+}
+
+function deriveAuthMode(
+  controller: Controller,
+): "signer" | "redirect" | "embedded" | "popup" {
+  if (controller instanceof PopupController) return "popup";
+  if (controller instanceof RedirectController) return "redirect";
+  if (controller instanceof IframeController) return "embedded";
+  return "signer";
+}
+
+export function createAbstraxionRuntime(
+  config: AbstraxionConfig,
+  options: AbstraxionRuntimeOptions = {},
+): AbstraxionRuntime {
+  const normalized = normalizeAbstraxionConfig(config);
+
+  const storageStrategy =
+    options.strategies?.storageStrategy ?? new BrowserStorageStrategy();
+  const redirectStrategy =
+    options.strategies?.redirectStrategy ?? new BrowserRedirectStrategy();
+
+  // Iframe transport: only needed for embedded mode. Default to the browser
+  // transport on the web; React Native consumers always supply their own
+  // (RNWebViewIframeTransport from @burnt-labs/abstraxion-react-native).
+  const isEmbeddedMode = normalized.authentication?.type === "embedded";
+  const iframeTransportStrategy = isEmbeddedMode
+    ? (options.strategies?.iframeTransportStrategy ??
+      new BrowserIframeTransportStrategy())
+    : options.strategies?.iframeTransportStrategy;
+
+  const controller = createController(normalized, {
+    storageStrategy,
+    redirectStrategy,
+    iframeTransportStrategy,
+  });
+
+  const authMode = deriveAuthMode(controller);
+  const isManageAuthSupported =
+    controller instanceof PopupController ||
+    controller instanceof IframeController ||
+    controller instanceof RedirectController;
+  const manageAuthUnsupportedReason = isManageAuthSupported
+    ? undefined
+    : `Manage authenticators is not supported in ${authMode} mode. ` +
+      `Use popup, redirect, or embedded authentication to add or remove authenticators.`;
+
+  let initializePromise: Promise<void> | null = null;
+  let readClientPromise: Promise<CosmWasmClient> | null = null;
+
+  // Dev-mode sanity check: warn when grant-based dashboard modes are configured
+  // without any grants. Lifted from the React provider so every framework
+  // wrapper gets the same nudge.
+  if (typeof process !== "undefined" && process.env?.NODE_ENV !== "production") {
+    const { treasury, contracts, stake, bank } = normalized;
+    const hasGrants =
+      !!treasury ||
+      (contracts && contracts.length > 0) ||
+      !!stake ||
+      (bank && bank.length > 0);
+    const isDashboardMode =
+      authMode === "popup" ||
+      authMode === "redirect" ||
+      authMode === "embedded";
+    if (!hasGrants && isDashboardMode) {
+      console.warn(
+        "[abstraxion-runtime] No grants configured (treasury, contracts, stake, or bank). " +
+          "In popup/redirect/embedded modes the user will authenticate and get a session key, " +
+          "but no on-chain permissions will be granted to it. " +
+          "This is intentional if you are using requireAuth (direct signing), where the user " +
+          "signs transactions directly from their meta-account rather than via a session key. " +
+          "If you expected grant-based signing, add a `treasury` address or legacy grant config.",
+      );
+    }
+  }
+
+  const runtime: AbstraxionRuntime = {
+    controller,
+    config: normalized,
+    authMode,
+    getState: () => controller.getState(),
+    subscribe: (cb) => controller.subscribe(cb),
+    subscribeApproval: (cb) => {
+      if (controller instanceof IframeController) {
+        return controller.subscribeApproval(cb);
+      }
+      return () => {};
+    },
+    getApprovalState: () => {
+      if (controller instanceof IframeController) {
+        return controller.awaitingApproval;
+      }
+      return false;
+    },
+    initialize: () => {
+      if (!initializePromise) {
+        initializePromise = controller.initialize();
+      }
+      return initializePromise;
+    },
+    login: () => controller.connect(),
+    logout: () => controller.disconnect(),
+    isManageAuthSupported,
+    manageAuthUnsupportedReason,
+    manageAuthenticators: async (granterAddress) => {
+      if (
+        controller instanceof PopupController ||
+        controller instanceof IframeController ||
+        controller instanceof RedirectController
+      ) {
+        return controller.promptManageAuthenticators(granterAddress);
+      }
+      throw new Error(
+        manageAuthUnsupportedReason ??
+          "manageAuthenticators is only supported in popup, redirect, and embedded modes.",
+      );
+    },
+    createReadClient: () => {
+      if (!readClientPromise) {
+        readClientPromise = CosmWasmClient.connect(normalized.rpcUrl).catch(
+          (error) => {
+            // Reset on failure so the next call retries instead of returning
+            // a permanently rejected cached promise.
+            readClientPromise = null;
+            throw error;
+          },
+        );
+      }
+      return readClientPromise;
+    },
+    createDirectSigningClient: async () => {
+      if (controller instanceof PopupController) {
+        return new RequireSigningClient(
+          controller.promptSignAndBroadcast.bind(controller),
+          normalized.rpcUrl,
+        );
+      }
+      if (controller instanceof RedirectController) {
+        return new RequireSigningClient(
+          controller.promptSignAndBroadcast.bind(controller),
+          normalized.rpcUrl,
+        );
+      }
+      if (controller instanceof IframeController) {
+        return new RequireSigningClient(
+          controller.signAndBroadcastWithMetaAccount.bind(controller),
+          normalized.rpcUrl,
+        );
+      }
+
+      if (controller instanceof SignerController) {
+        const state = controller.getState();
+        if (!AccountStateGuards.isConnected(state)) {
+          throw new Error(
+            "createDirectSigningClient(): user is not connected. Call login() first.",
+          );
+        }
+        const connectionInfo = controller.getConnectionInfo?.();
+        if (!connectionInfo) {
+          throw new Error(
+            "createDirectSigningClient(): SignerController has no connectionInfo — login may have failed.",
+          );
+        }
+        const authenticatorType = connectionInfo.metadata
+          ?.authenticatorType as AuthenticatorType | undefined;
+        const authenticatorIndex =
+          (connectionInfo.metadata?.authenticatorIndex as
+            | number
+            | undefined) ?? 0;
+        if (
+          !authenticatorType ||
+          !Object.values(AUTHENTICATOR_TYPE).includes(authenticatorType)
+        ) {
+          throw new Error(
+            `createDirectSigningClient(): connectionInfo.metadata.authenticatorType is missing or invalid (got: ${String(authenticatorType)}).`,
+          );
+        }
+        const signer = createSignerFromSigningFunction({
+          smartAccountAddress: state.account.granterAddress,
+          authenticatorIndex,
+          authenticatorType,
+          signMessage: connectionInfo.signMessage,
+        });
+        return AAClient.connectWithSigner(normalized.rpcUrl, signer, {
+          gasPrice: GasPrice.fromString(normalized.gasPrice),
+        });
+      }
+
+      return undefined;
+    },
+    updateGetSignerConfig: (fn) => {
+      if (controller instanceof SignerController) {
+        controller.updateGetSignerConfig(fn);
+      }
+    },
+    destroy: () => {
+      readClientPromise = null;
+      controller.destroy();
+    },
+  };
+
+  if (options.autoInitialize !== false) {
+    runtime.initialize().catch((error) => {
+      console.error("[abstraxion-runtime] initialize() failed:", error);
+    });
+  }
+
+  return runtime;
+}

--- a/packages/abstraxion-js/src/runtime.ts
+++ b/packages/abstraxion-js/src/runtime.ts
@@ -129,9 +129,7 @@ export interface AbstraxionRuntime {
    * No-op outside signer mode.
    */
   updateGetSignerConfig(
-    fn: NonNullable<
-      import("./types").SignerAuthentication["getSignerConfig"]
-    >,
+    fn: NonNullable<import("./types").SignerAuthentication["getSignerConfig"]>,
   ): void;
   /** Tear down listeners + iframe (delegates to `controller.destroy()`). */
   destroy(): void;
@@ -188,7 +186,10 @@ export function createAbstraxionRuntime(
   // Dev-mode sanity check: warn when grant-based dashboard modes are configured
   // without any grants. Lifted from the React provider so every framework
   // wrapper gets the same nudge.
-  if (typeof process !== "undefined" && process.env?.NODE_ENV !== "production") {
+  if (
+    typeof process !== "undefined" &&
+    process.env?.NODE_ENV !== "production"
+  ) {
     const { treasury, contracts, stake, bank } = normalized;
     const hasGrants =
       !!treasury ||
@@ -298,12 +299,12 @@ export function createAbstraxionRuntime(
             "createDirectSigningClient(): SignerController has no connectionInfo — login may have failed.",
           );
         }
-        const authenticatorType = connectionInfo.metadata
-          ?.authenticatorType as AuthenticatorType | undefined;
+        const authenticatorType = connectionInfo.metadata?.authenticatorType as
+          | AuthenticatorType
+          | undefined;
         const authenticatorIndex =
-          (connectionInfo.metadata?.authenticatorIndex as
-            | number
-            | undefined) ?? 0;
+          (connectionInfo.metadata?.authenticatorIndex as number | undefined) ??
+          0;
         if (
           !authenticatorType ||
           !Object.values(AUTHENTICATOR_TYPE).includes(authenticatorType)

--- a/packages/abstraxion-js/src/strategies/BrowserIframeTransportStrategy.ts
+++ b/packages/abstraxion-js/src/strategies/BrowserIframeTransportStrategy.ts
@@ -1,0 +1,167 @@
+/**
+ * Browser implementation of `IframeTransportStrategy`. Encapsulates `<iframe>`
+ * DOM manipulation and the existing `MessageChannelManager` request/response
+ * protocol used by the dashboard.
+ */
+
+import { MessageChannelManager } from "@burnt-labs/abstraxion-core";
+import type { IframeMessageType } from "@burnt-labs/abstraxion-core";
+
+import type {
+  IframeMountContext,
+  IframeTransportStrategy,
+} from "./IframeTransportStrategy";
+
+export class BrowserIframeTransportStrategy implements IframeTransportStrategy {
+  private container: HTMLElement | null = null;
+  private iframe: HTMLIFrameElement | null = null;
+  private origin: string | null = null;
+  private messageManager = new MessageChannelManager();
+  private pushListeners = new Set<(data: unknown) => void>();
+  private windowMessageHandler: ((event: MessageEvent) => void) | null = null;
+  private readyResolvers: Array<() => void> = [];
+
+  setContainer(container: unknown): void {
+    if (container instanceof HTMLElement || container === null) {
+      this.container = container;
+    } else {
+      throw new TypeError(
+        "[BrowserIframeTransportStrategy] container must be an HTMLElement or null",
+      );
+    }
+  }
+
+  hasContainer(): boolean {
+    return !!this.container;
+  }
+
+  isMounted(): boolean {
+    return !!this.iframe;
+  }
+
+  mount({ url, origin }: IframeMountContext): void {
+    if (!this.container) {
+      throw new Error(
+        "containerElement is required for iframe mode. " +
+          "Provide a DOM element where the iframe should be mounted.",
+      );
+    }
+    this.origin = origin;
+
+    if (this.iframe) {
+      this.iframe.src = url;
+      return;
+    }
+
+    const iframe = document.createElement("iframe");
+    iframe.src = url;
+    iframe.style.width = "100%";
+    iframe.style.height = "100%";
+    iframe.style.border = "none";
+    iframe.allow = `publickey-credentials-get ${origin}; clipboard-read; clipboard-write`;
+    this.container.appendChild(iframe);
+    this.iframe = iframe;
+
+    this.attachWindowListener();
+  }
+
+  navigate(url: string): void {
+    if (this.iframe) {
+      this.iframe.src = url;
+    }
+  }
+
+  waitForReady(timeoutMs: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const idx = this.readyResolvers.indexOf(resolve);
+        if (idx >= 0) this.readyResolvers.splice(idx, 1);
+        reject(
+          new Error(`Iframe did not become ready within ${timeoutMs}ms`),
+        );
+      }, timeoutMs);
+
+      this.readyResolvers.push(() => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+  }
+
+  async sendRequest<TRequest, TResponse>(
+    type: IframeMessageType,
+    payload: TRequest,
+    timeoutMs: number,
+  ): Promise<TResponse> {
+    if (!this.iframe?.contentWindow) {
+      throw new Error(
+        "Iframe is not available. Ensure the iframe is mounted and the user is connected.",
+      );
+    }
+    if (!this.origin) {
+      throw new Error(
+        "Iframe origin is not set. Mount the iframe before sending requests.",
+      );
+    }
+    return this.messageManager.sendRequest<TRequest, TResponse>(
+      this.iframe,
+      type,
+      payload,
+      this.origin,
+      timeoutMs,
+    );
+  }
+
+  onPushMessage(listener: (data: unknown) => void): () => void {
+    this.pushListeners.add(listener);
+    return () => this.pushListeners.delete(listener);
+  }
+
+  setVisible(_visible: boolean): void {
+    // Browser: visibility is owned by `<AbstraxionEmbed>` which sizes the
+    // container element, not by the transport itself.
+  }
+
+  unmount(): void {
+    this.detachWindowListener();
+    if (this.iframe?.parentNode) {
+      this.iframe.parentNode.removeChild(this.iframe);
+    }
+    this.iframe = null;
+    this.origin = null;
+    this.readyResolvers.length = 0;
+  }
+
+  private attachWindowListener(): void {
+    if (this.windowMessageHandler) return;
+
+    const handler = (event: MessageEvent) => {
+      if (!this.origin || event.origin !== this.origin) return;
+      const data = event.data as { type?: string } | undefined;
+      if (!data || typeof data.type !== "string") return;
+
+      if (data.type === "IFRAME_READY") {
+        const resolvers = this.readyResolvers.splice(0);
+        resolvers.forEach((r) => r());
+        return;
+      }
+
+      // Skip MessageChannel-routed responses (they carry a `requestId` we
+      // don't observe here). Anything else is a "push" event from the dashboard.
+      if (data.type === "HARD_DISCONNECT" || data.type === "DISCONNECT") {
+        this.pushListeners.forEach((listener) => listener(data));
+      }
+    };
+
+    this.windowMessageHandler = handler;
+    window.addEventListener("message", handler);
+  }
+
+  private detachWindowListener(): void {
+    if (this.windowMessageHandler) {
+      window.removeEventListener("message", this.windowMessageHandler);
+      this.windowMessageHandler = null;
+    }
+    this.pushListeners.clear();
+  }
+}

--- a/packages/abstraxion-js/src/strategies/BrowserIframeTransportStrategy.ts
+++ b/packages/abstraxion-js/src/strategies/BrowserIframeTransportStrategy.ts
@@ -76,9 +76,7 @@ export class BrowserIframeTransportStrategy implements IframeTransportStrategy {
       const timeout = setTimeout(() => {
         const idx = this.readyResolvers.indexOf(resolve);
         if (idx >= 0) this.readyResolvers.splice(idx, 1);
-        reject(
-          new Error(`Iframe did not become ready within ${timeoutMs}ms`),
-        );
+        reject(new Error(`Iframe did not become ready within ${timeoutMs}ms`));
       }, timeoutMs);
 
       this.readyResolvers.push(() => {

--- a/packages/abstraxion-js/src/strategies/BrowserRedirectStrategy.ts
+++ b/packages/abstraxion-js/src/strategies/BrowserRedirectStrategy.ts
@@ -1,24 +1,9 @@
-import type {
-  RedirectStrategy,
-  StorageStrategy,
-} from "@burnt-labs/abstraxion-core";
+import type { RedirectStrategy } from "@burnt-labs/abstraxion-core";
 
-export class BrowserStorageStrategy implements StorageStrategy {
-  async getItem(key: string): Promise<string | null> {
-    return Promise.resolve(localStorage.getItem(key));
-  }
-
-  async setItem(key: string, value: string): Promise<void> {
-    localStorage.setItem(key, value);
-    return Promise.resolve();
-  }
-
-  async removeItem(key: string): Promise<void> {
-    localStorage.removeItem(key);
-    return Promise.resolve();
-  }
-}
-
+/**
+ * Browser implementation of `RedirectStrategy` backed by `window.location`
+ * and `URLSearchParams`.
+ */
 export class BrowserRedirectStrategy implements RedirectStrategy {
   async getCurrentUrl(): Promise<string> {
     return Promise.resolve(window.location.href);

--- a/packages/abstraxion-js/src/strategies/BrowserStorageStrategy.ts
+++ b/packages/abstraxion-js/src/strategies/BrowserStorageStrategy.ts
@@ -1,0 +1,20 @@
+import type { StorageStrategy } from "@burnt-labs/abstraxion-core";
+
+/**
+ * Browser implementation of `StorageStrategy` backed by `localStorage`.
+ */
+export class BrowserStorageStrategy implements StorageStrategy {
+  async getItem(key: string): Promise<string | null> {
+    return Promise.resolve(localStorage.getItem(key));
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    localStorage.setItem(key, value);
+    return Promise.resolve();
+  }
+
+  async removeItem(key: string): Promise<void> {
+    localStorage.removeItem(key);
+    return Promise.resolve();
+  }
+}

--- a/packages/abstraxion-js/src/strategies/IframeTransportStrategy.ts
+++ b/packages/abstraxion-js/src/strategies/IframeTransportStrategy.ts
@@ -1,0 +1,62 @@
+/**
+ * Iframe transport strategy contract.
+ *
+ * Abstracts the host-specific details of mounting the dashboard somewhere
+ * users can see and interact with it (`<iframe>` on the web, `<WebView>` on
+ * React Native, etc.) and routing request/response + push messages between
+ * the SDK and the dashboard app running inside it.
+ *
+ * This is the third platform-injected strategy in `@burnt-labs/abstraxion-js`,
+ * alongside `StorageStrategy` and `RedirectStrategy`. Embedded mode is the
+ * only mode that needs it; popup, redirect, and signer modes do not.
+ */
+
+import type { IframeMessageType } from "@burnt-labs/abstraxion-core";
+
+/**
+ * Host-managed handle for a mounted iframe / WebView. Treated as opaque by
+ * the controller — only the transport itself reads its internals.
+ */
+export interface IframeMountContext {
+  /** Origin of the loaded URL, used as `targetOrigin` for postMessage. */
+  origin: string;
+  /** Initial src to load. */
+  url: string;
+}
+
+/**
+ * Strategy contract. All methods are sync except `sendRequest` and
+ * `waitForReady`, which await dashboard cooperation.
+ */
+export interface IframeTransportStrategy {
+  /** Bind a host-supplied container for subsequent `mount()` calls. */
+  setContainer(container: unknown): void;
+  /** True after `setContainer()` has been called with a non-null container. */
+  hasContainer(): boolean;
+  /** Mount the iframe/WebView at `url`. Idempotent — replaces src if already mounted. */
+  mount(context: IframeMountContext): void;
+  /** Update the loaded URL on an already-mounted iframe/WebView. */
+  navigate(url: string): void;
+  /** True if currently mounted. */
+  isMounted(): boolean;
+  /** Wait for the dashboard's IFRAME_READY handshake. Resolves once received. */
+  waitForReady(timeoutMs: number): Promise<void>;
+  /**
+   * Send a request and resolve with the dashboard's response. Each call uses
+   * an isolated channel (browser: `MessageChannel`; RN: requestId envelope).
+   */
+  sendRequest<TRequest, TResponse>(
+    type: IframeMessageType,
+    payload: TRequest,
+    timeoutMs: number,
+  ): Promise<TResponse>;
+  /**
+   * Subscribe to push events from the dashboard (HARD_DISCONNECT etc.).
+   * Returns an unsubscribe function.
+   */
+  onPushMessage(listener: (data: unknown) => void): () => void;
+  /** Show / hide the mounted iframe/WebView. No-op for hosts that delegate to a host component. */
+  setVisible(visible: boolean): void;
+  /** Remove the iframe/WebView and detach listeners. */
+  unmount(): void;
+}

--- a/packages/abstraxion-react-native/package.json
+++ b/packages/abstraxion-react-native/package.json
@@ -30,7 +30,13 @@
     "react": ">=18.0.0",
     "react-native": ">=0.75.0",
     "react-native-get-random-values": "^1.11.0",
-    "react-native-quick-crypto": "^0.7.0"
+    "react-native-quick-crypto": "^0.7.0",
+    "react-native-webview": ">=13.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-webview": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@burnt-labs/abstraxion-js": "workspace:*",

--- a/packages/abstraxion-react-native/src/components/AbstraxionContext/index.tsx
+++ b/packages/abstraxion-react-native/src/components/AbstraxionContext/index.tsx
@@ -1,30 +1,28 @@
-import type { Dispatch, ReactNode, SetStateAction } from "react";
-import { createContext, useCallback, useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { createContext, useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import {
   AccountStateGuards,
-  createController,
+  createAbstraxionRuntime,
   GasPrice,
-  normalizeAbstraxionConfig,
-  SignerController,
   testnetChainInfo,
 } from "@burnt-labs/abstraxion-js";
 import type {
   AbstraxionConfig as AbstraxionJsConfig,
+  AbstraxionRuntime,
   AccountState,
   ConnectorConnectionResult,
   ContractGrantDescription,
   Controller,
+  EmbeddedAuthentication,
   GranteeSignerClient,
-  NormalizedAbstraxionConfig,
   RedirectAuthentication,
   SignArbSecp256k1HdWallet,
   SignerAuthentication,
   SpendLimit,
 } from "@burnt-labs/abstraxion-js";
-import {
-  ReactNativeRedirectStrategy,
-  ReactNativeStorageStrategy,
-} from "../../strategies";
+import { ReactNativeRedirectStrategy } from "../../strategies/ReactNativeRedirectStrategy";
+import { ReactNativeStorageStrategy } from "../../strategies/ReactNativeStorageStrategy";
+import { RNWebViewIframeTransport } from "../../strategies/RNWebViewIframeTransport";
 
 export type {
   ContractGrantDescription,
@@ -34,38 +32,31 @@ export type {
 /**
  * Authentication modes supported in React Native.
  *
- * `popup`, `embedded`, and `auto` are web-only:
+ * - `redirect` — Expo WebBrowser + deep link callback (primary mode)
+ * - `signer` — Injected signing function (Turnkey, Privy, etc.)
+ * - `embedded` — Dashboard inside a `<react-native-webview>` `<WebView>` (Phase 9b)
+ *
+ * `popup` and `auto` are still web-only:
  * - `popup` requires `window.open` + same-origin `postMessage`.
- * - `embedded` requires a DOM `<iframe>` (a WebView-based equivalent is tracked as a follow-up).
- * - `auto` resolves to `popup` on desktop and would silently fall through here; consumers
- *   on RN must pick `redirect` or `signer` explicitly.
+ * - `auto` resolves to `popup` on desktop and would silently fall through here.
  */
 export type ReactNativeAuthenticationConfig =
   | RedirectAuthentication
-  | SignerAuthentication;
+  | SignerAuthentication
+  | EmbeddedAuthentication;
 
 export interface AbstraxionContextProps {
   isConnected: boolean;
-  setIsConnected: Dispatch<SetStateAction<boolean>>;
   isConnecting: boolean;
-  setIsConnecting: Dispatch<SetStateAction<boolean>>;
   isInitializing: boolean;
   isDisconnected: boolean;
+  isAwaitingApproval: boolean;
   isReturningFromAuth: boolean;
   isLoggingIn: boolean;
   abstraxionError: string;
-  setAbstraxionError: Dispatch<SetStateAction<string>>;
   abstraxionAccount: SignArbSecp256k1HdWallet | undefined;
-  setAbstraxionAccount: Dispatch<
-    SetStateAction<SignArbSecp256k1HdWallet | undefined>
-  >;
   granterAddress: string;
-  showModal: boolean;
-  setShowModal: Dispatch<SetStateAction<boolean>>;
-  setGranterAddress: Dispatch<SetStateAction<string>>;
   contracts?: ContractGrantDescription[];
-  dashboardUrl?: string;
-  setDashboardUrl: Dispatch<SetStateAction<string>>;
   chainId: string;
   rpcUrl: string;
   restUrl: string;
@@ -75,10 +66,11 @@ export interface AbstraxionContextProps {
   indexerUrl?: string;
   gasPrice: GasPrice;
   signingClient?: GranteeSignerClient;
-  authMode: "signer" | "redirect";
+  authMode: "signer" | "redirect" | "embedded";
   authentication?: ReactNativeAuthenticationConfig;
   connectionInfo?: ConnectorConnectionResult;
   controller?: Controller;
+  runtime?: AbstraxionRuntime;
   logout: () => Promise<void>;
   login: () => Promise<void>;
 }
@@ -91,43 +83,25 @@ export interface AbstraxionConfig extends Omit<
   callbackUrl?: string;
   indexerUrl?: string;
   /**
-   * React Native only supports `redirect` (Expo WebBrowser + deep link) and `signer`
-   * (injected signing function). `popup`, `embedded`, and `auto` are web-only — see
-   * {@link ReactNativeAuthenticationConfig}.
+   * React Native supports `redirect` (Expo WebBrowser + deep link), `signer`
+   * (injected signing function), and (since Phase 9b) `embedded` (in-app
+   * `<WebView>`). `popup` and `auto` are web-only.
    */
   authentication?: ReactNativeAuthenticationConfig;
 }
 
-const noopBooleanDispatch = (() => undefined) as Dispatch<
-  SetStateAction<boolean>
->;
-const noopStringDispatch = (() => undefined) as Dispatch<
-  SetStateAction<string>
->;
-const noopAccountDispatch = (() => undefined) as Dispatch<
-  SetStateAction<SignArbSecp256k1HdWallet | undefined>
->;
-
 const defaultContextValue: AbstraxionContextProps = {
   isConnected: false,
-  setIsConnected: noopBooleanDispatch,
   isConnecting: false,
-  setIsConnecting: noopBooleanDispatch,
   isInitializing: true,
   isDisconnected: false,
+  isAwaitingApproval: false,
   isReturningFromAuth: false,
   isLoggingIn: false,
   abstraxionError: "",
-  setAbstraxionError: noopStringDispatch,
   abstraxionAccount: undefined,
-  setAbstraxionAccount: noopAccountDispatch,
   granterAddress: "",
-  showModal: false,
-  setShowModal: noopBooleanDispatch,
-  setGranterAddress: noopStringDispatch,
   contracts: undefined,
-  dashboardUrl: "",
-  setDashboardUrl: noopStringDispatch,
   chainId: testnetChainInfo.chainId,
   rpcUrl: testnetChainInfo.rpc,
   restUrl: testnetChainInfo.rest,
@@ -137,10 +111,11 @@ const defaultContextValue: AbstraxionContextProps = {
   indexerUrl: undefined,
   gasPrice: GasPrice.fromString("0.001uxion"),
   signingClient: undefined,
-  authMode: "redirect" as "signer" | "redirect",
+  authMode: "redirect",
   authentication: undefined,
   connectionInfo: undefined,
   controller: undefined,
+  runtime: undefined,
   logout: () => {
     return Promise.reject(
       new Error("AbstraxionContext: logout() called before provider mounted."),
@@ -166,16 +141,18 @@ function resolveReactNativeAuthentication(
       : { type: "redirect" };
   }
 
-  // Defensive runtime guard: TypeScript narrows AbstraxionConfig.authentication to
-  // ReactNativeAuthenticationConfig, but consumers using `as any` or untyped JS would
-  // otherwise silently crash later in createController. Fail fast with a clear message.
-  if (authentication.type !== "redirect" && authentication.type !== "signer") {
+  // Defensive runtime guard for non-TS callers using `as any`.
+  if (
+    authentication.type !== "redirect" &&
+    authentication.type !== "signer" &&
+    authentication.type !== "embedded"
+  ) {
     throw new Error(
       `[abstraxion-react-native] Authentication mode "${
         (authentication as { type: string }).type
       }" is not supported on React Native. ` +
-        `Use { type: "redirect" } (Expo WebBrowser) or { type: "signer" } (injected signing). ` +
-        `popup, embedded, and auto are web-only.`,
+        `Use { type: "redirect" } (Expo WebBrowser), { type: "signer" } (injected signing), ` +
+        `or { type: "embedded" } (react-native-webview). popup and auto are web-only.`,
     );
   }
 
@@ -193,27 +170,6 @@ function resolveReactNativeAuthentication(
   return authentication;
 }
 
-function normalizeReactNativeConfig(
-  config: AbstraxionConfig,
-): NormalizedAbstraxionConfig {
-  const {
-    callbackUrl,
-    indexerUrl: _indexerUrl,
-    chainId,
-    authentication,
-    ...rest
-  } = config;
-
-  return normalizeAbstraxionConfig({
-    ...rest,
-    chainId: chainId ?? testnetChainInfo.chainId,
-    authentication: resolveReactNativeAuthentication(
-      authentication,
-      callbackUrl,
-    ),
-  });
-}
-
 export function AbstraxionProvider({
   children,
   config,
@@ -221,83 +177,78 @@ export function AbstraxionProvider({
   children: ReactNode;
   config: AbstraxionConfig;
 }): JSX.Element {
-  const normalizedConfig = normalizeReactNativeConfig(config);
-  const controllerRef = useRef<Controller | null>(null);
-  const configRef = useRef<NormalizedAbstraxionConfig>(normalizedConfig);
-  const strategiesRef = useRef<{
-    storageStrategy: ReactNativeStorageStrategy;
-    redirectStrategy: ReactNativeRedirectStrategy;
-  } | null>(null);
-
-  if (!strategiesRef.current) {
-    strategiesRef.current = {
-      storageStrategy: new ReactNativeStorageStrategy(),
-      redirectStrategy: new ReactNativeRedirectStrategy(),
+  const resolvedConfig = useMemo<AbstraxionJsConfig>(() => {
+    const { callbackUrl, indexerUrl: _indexerUrl, chainId, authentication, ...rest } = config;
+    return {
+      ...rest,
+      chainId: chainId ?? testnetChainInfo.chainId,
+      authentication: resolveReactNativeAuthentication(authentication, callbackUrl),
     };
+  }, [config]);
+
+  // Singleton runtime — controllers are heavy; recreating breaks redirect
+  // callback detection across remounts.
+  const runtimeRef = useRef<AbstraxionRuntime | null>(null);
+  if (!runtimeRef.current) {
+    runtimeRef.current = createAbstraxionRuntime(resolvedConfig, {
+      autoInitialize: false,
+      strategies: {
+        storageStrategy: new ReactNativeStorageStrategy(),
+        redirectStrategy: new ReactNativeRedirectStrategy(),
+        // Always supply the RN transport — only used when authentication.type === "embedded".
+        iframeTransportStrategy:
+          resolvedConfig.authentication?.type === "embedded"
+            ? new RNWebViewIframeTransport()
+            : undefined,
+      },
+    });
   }
+  const runtime = runtimeRef.current;
+  const controller = runtime.controller;
+  const normalizedConfig = runtime.config;
+  const authMode: "signer" | "redirect" | "embedded" =
+    runtime.authMode === "embedded"
+      ? "embedded"
+      : runtime.authMode === "signer"
+        ? "signer"
+        : "redirect";
 
-  const previousConfig = configRef.current;
-
-  if (!controllerRef.current) {
-    controllerRef.current = createController(
-      normalizedConfig,
-      strategiesRef.current,
-    );
-    configRef.current = normalizedConfig;
-  } else {
-    const isSignerMode =
-      previousConfig.authentication?.type === "signer" &&
-      normalizedConfig.authentication?.type === "signer";
-    const hasSignerConfigChanged =
-      isSignerMode &&
-      previousConfig.authentication?.type === "signer" &&
-      normalizedConfig.authentication?.type === "signer" &&
-      previousConfig.authentication.getSignerConfig !==
-        normalizedConfig.authentication.getSignerConfig;
-
-    if (
-      hasSignerConfigChanged &&
-      controllerRef.current instanceof SignerController &&
-      normalizedConfig.authentication?.type === "signer"
-    ) {
-      controllerRef.current.updateGetSignerConfig(
-        normalizedConfig.authentication.getSignerConfig,
-      );
+  // Update dynamic getSignerConfig if the consumer swaps it in (Turnkey/Privy
+  // patterns where the authenticated function arrives after first render).
+  // Run as an effect so the controller mutation happens post-commit.
+  const incomingSignerConfig =
+    config.authentication?.type === "signer"
+      ? config.authentication.getSignerConfig
+      : undefined;
+  useEffect(() => {
+    if (incomingSignerConfig) {
+      runtime.updateGetSignerConfig(incomingSignerConfig);
     }
+  }, [runtime, incomingSignerConfig]);
 
-    configRef.current = normalizedConfig;
-  }
-
-  const controller = controllerRef.current;
-  const [controllerState, setControllerState] = useState<AccountState>(
-    controller.getState(),
+  const controllerState = useSyncExternalStore<AccountState>(
+    runtime.subscribe,
+    runtime.getState,
+    runtime.getState,
   );
-  const [manualError, setAbstraxionError] = useState("");
-  const [manualAccount, setAbstraxionAccount] = useState<
-    SignArbSecp256k1HdWallet | undefined
-  >(undefined);
-  const [manualGranterAddress, setGranterAddress] = useState("");
-  const [showModal, setShowModal] = useState(false);
-  const [dashboardUrlOverride, setDashboardUrl] = useState("");
 
-  const authMode: "signer" | "redirect" =
-    controller instanceof SignerController ? "signer" : "redirect";
+  const isAwaitingApproval = useSyncExternalStore(
+    runtime.subscribeApproval,
+    runtime.getApprovalState,
+    runtime.getApprovalState,
+  );
 
   useEffect(() => {
-    const unsubscribe = controller.subscribe(setControllerState);
-
-    controller.initialize().catch((error) => {
+    runtime.initialize().catch((error) => {
       console.error(
         "[AbstraxionProvider] Controller initialization failed:",
         error,
       );
     });
-
     return () => {
-      unsubscribe();
-      controller.destroy();
+      runtime.destroy();
     };
-  }, [controller]);
+  }, [runtime]);
 
   const isInitializing = AccountStateGuards.isInitializing(controllerState);
   const isConnecting =
@@ -313,77 +264,77 @@ export function AbstraxionProvider({
 
   const abstraxionAccount = isConnected
     ? controllerState.account.keypair
-    : manualAccount;
+    : undefined;
   const granterAddress = isConnected
     ? controllerState.account.granterAddress
-    : manualGranterAddress;
+    : "";
   const signingClient = isConnected ? controllerState.signingClient : undefined;
-  const abstraxionError = isError ? controllerState.error : manualError;
-  const dashboardUrl = AccountStateGuards.isRedirecting(controllerState)
-    ? controllerState.dashboardUrl
-    : dashboardUrlOverride;
+  const abstraxionError = isError ? controllerState.error : "";
 
   const connectionInfo =
-    isConnected &&
-    controller instanceof SignerController &&
-    controller.getConnectionInfo
-      ? controller.getConnectionInfo()
+    isConnected && controller && typeof (controller as Controller).getConnectionInfo === "function"
+      ? (controller as Controller).getConnectionInfo?.()
       : undefined;
 
-  const login = useCallback(async () => {
-    setAbstraxionError("");
-    await controller.connect();
-  }, [controller]);
+  const login = useCallback(() => runtime.login(), [runtime]);
+  const logout = useCallback(() => runtime.logout(), [runtime]);
 
-  const logout = useCallback(async () => {
-    setAbstraxionError("");
-    setAbstraxionAccount(undefined);
-    setGranterAddress("");
-    await controller.disconnect();
-  }, [controller]);
+  const contextValue = useMemo<AbstraxionContextProps>(
+    () => ({
+      isConnected,
+      isConnecting,
+      isInitializing,
+      isDisconnected,
+      isAwaitingApproval,
+      isReturningFromAuth,
+      isLoggingIn,
+      abstraxionError,
+      abstraxionAccount,
+      granterAddress,
+      contracts: normalizedConfig.contracts,
+      chainId: normalizedConfig.chainId,
+      rpcUrl: normalizedConfig.rpcUrl,
+      restUrl: normalizedConfig.restUrl,
+      stake: normalizedConfig.stake,
+      bank: normalizedConfig.bank,
+      treasury: normalizedConfig.treasury,
+      indexerUrl: config.indexerUrl,
+      login,
+      logout,
+      gasPrice: GasPrice.fromString(normalizedConfig.gasPrice),
+      signingClient,
+      authMode,
+      authentication:
+        normalizedConfig.authentication as ReactNativeAuthenticationConfig,
+      connectionInfo,
+      controller,
+      runtime,
+    }),
+    [
+      isConnected,
+      isConnecting,
+      isInitializing,
+      isDisconnected,
+      isAwaitingApproval,
+      isReturningFromAuth,
+      isLoggingIn,
+      abstraxionError,
+      abstraxionAccount,
+      granterAddress,
+      normalizedConfig,
+      config.indexerUrl,
+      authMode,
+      signingClient,
+      connectionInfo,
+      controller,
+      runtime,
+      login,
+      logout,
+    ],
+  );
 
   return (
-    <AbstraxionContext.Provider
-      value={{
-        isConnected,
-        setIsConnected: noopBooleanDispatch,
-        isConnecting,
-        setIsConnecting: noopBooleanDispatch,
-        isInitializing,
-        isDisconnected,
-        isReturningFromAuth,
-        isLoggingIn,
-        abstraxionError,
-        setAbstraxionError,
-        abstraxionAccount,
-        setAbstraxionAccount,
-        granterAddress,
-        showModal,
-        setShowModal,
-        setGranterAddress,
-        contracts: normalizedConfig.contracts,
-        dashboardUrl,
-        setDashboardUrl,
-        chainId: normalizedConfig.chainId,
-        rpcUrl: normalizedConfig.rpcUrl,
-        restUrl: normalizedConfig.restUrl,
-        stake: normalizedConfig.stake,
-        bank: normalizedConfig.bank,
-        treasury: normalizedConfig.treasury,
-        indexerUrl: config.indexerUrl,
-        login,
-        logout,
-        gasPrice: GasPrice.fromString(normalizedConfig.gasPrice),
-        signingClient,
-        authMode,
-        // resolveReactNativeAuthentication has already narrowed/asserted this
-        // to ReactNativeAuthenticationConfig before normalizeAbstraxionConfig ran.
-        authentication:
-          normalizedConfig.authentication as ReactNativeAuthenticationConfig,
-        connectionInfo,
-        controller,
-      }}
-    >
+    <AbstraxionContext.Provider value={contextValue}>
       {children}
     </AbstraxionContext.Provider>
   );

--- a/packages/abstraxion-react-native/src/components/AbstraxionContext/index.tsx
+++ b/packages/abstraxion-react-native/src/components/AbstraxionContext/index.tsx
@@ -1,5 +1,12 @@
 import type { ReactNode } from "react";
-import { createContext, useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import {
   AccountStateGuards,
   createAbstraxionRuntime,
@@ -178,11 +185,20 @@ export function AbstraxionProvider({
   config: AbstraxionConfig;
 }): JSX.Element {
   const resolvedConfig = useMemo<AbstraxionJsConfig>(() => {
-    const { callbackUrl, indexerUrl: _indexerUrl, chainId, authentication, ...rest } = config;
+    const {
+      callbackUrl,
+      indexerUrl: _indexerUrl,
+      chainId,
+      authentication,
+      ...rest
+    } = config;
     return {
       ...rest,
       chainId: chainId ?? testnetChainInfo.chainId,
-      authentication: resolveReactNativeAuthentication(authentication, callbackUrl),
+      authentication: resolveReactNativeAuthentication(
+        authentication,
+        callbackUrl,
+      ),
     };
   }, [config]);
 
@@ -272,7 +288,9 @@ export function AbstraxionProvider({
   const abstraxionError = isError ? controllerState.error : "";
 
   const connectionInfo =
-    isConnected && controller && typeof (controller as Controller).getConnectionInfo === "function"
+    isConnected &&
+    controller &&
+    typeof (controller as Controller).getConnectionInfo === "function"
       ? (controller as Controller).getConnectionInfo?.()
       : undefined;
 

--- a/packages/abstraxion-react-native/src/components/AbstraxionEmbed.tsx
+++ b/packages/abstraxion-react-native/src/components/AbstraxionEmbed.tsx
@@ -1,0 +1,298 @@
+/**
+ * React Native equivalent of `<AbstraxionEmbed>` from `@burnt-labs/abstraxion-react`.
+ *
+ * Renders the dashboard inside a `react-native-webview` `WebView`, bridges
+ * messages to/from native via `RNWebViewIframeTransport`, and exposes the
+ * same `idleView` / `connectedView` / `approvalView` props as the web embed.
+ *
+ * `react-native-webview` is an optional peer dependency — we lazy-require it
+ * inside the component so users on `redirect`/`signer` modes don't pay the
+ * native module cost.
+ */
+
+import {
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import type { ViewStyle } from "react-native";
+import { IframeController } from "@burnt-labs/abstraxion-js";
+import type { IframeTransportStrategy } from "@burnt-labs/abstraxion-js";
+import { AbstraxionContext } from "../components/AbstraxionContext";
+import {
+  RNWebViewIframeTransport,
+  type RNWebViewControl,
+} from "../strategies/RNWebViewIframeTransport";
+
+type InactiveView = "button" | "fullview" | "hidden";
+
+export interface AbstraxionEmbedProps {
+  idleView?: InactiveView;
+  disconnectedView?: InactiveView;
+  /** What to show when connected with no pending approval. Default: "hidden". */
+  connectedView?: "hidden" | "visible";
+  /** Approval display: in-app modal overlay (default) or inline. */
+  approvalView?: "modal" | "inline";
+  loginLabel?: ReactNode;
+  /** Style for the WebView wrapper. Required when connectedView="visible". */
+  style?: ViewStyle;
+}
+
+export interface AbstraxionEmbedHandle {
+  /** Force a reload of the dashboard WebView (rarely needed). */
+  reload(): void;
+}
+
+const collapsed: ViewStyle = {
+  width: 0,
+  height: 0,
+  overflow: "hidden",
+};
+
+/**
+ * Mounts the dashboard inside a WebView and wires it up to the active
+ * `IframeController` via `RNWebViewIframeTransport`. Place once at the root of
+ * your app — only one embed should be mounted at a time.
+ */
+export const AbstraxionEmbed = forwardRef<
+  AbstraxionEmbedHandle,
+  AbstraxionEmbedProps
+>(function AbstraxionEmbed(
+  {
+    idleView = "button",
+    disconnectedView,
+    connectedView = "hidden",
+    approvalView = "modal",
+    loginLabel = "Sign in with XION",
+    style,
+  },
+  forwardedRef,
+) {
+  const inactiveView = disconnectedView ?? idleView;
+
+  const {
+    controller,
+    isConnected,
+    isConnecting,
+    isDisconnected,
+    abstraxionError,
+    login,
+  } = useContext(AbstraxionContext) as unknown as {
+    controller?: import("@burnt-labs/abstraxion-js").Controller;
+    isConnected: boolean;
+    isConnecting: boolean;
+    isDisconnected: boolean;
+    abstraxionError: string;
+    login: () => Promise<void>;
+  };
+
+  // Lazily require react-native-webview so consumers that don't use embedded
+  // mode aren't forced to install it.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const WebViewRef = useRef<any>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const WebViewModule = useMemo<any>(() => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      return require("react-native-webview");
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const transport = useMemo(() => {
+    if (!(controller instanceof IframeController)) return null;
+    const strategy = controller.getTransportStrategy();
+    return strategy instanceof RNWebViewIframeTransport ? strategy : null;
+  }, [controller]);
+
+  // Track approval-pending state for modal display.
+  const [isAwaitingApproval, setIsAwaitingApproval] = useState(false);
+  useEffect(() => {
+    if (!(controller instanceof IframeController)) return;
+    return controller.subscribeApproval(setIsAwaitingApproval);
+  }, [controller]);
+
+  // Track WebView load + bridge ready.
+  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
+  const containerRegisteredRef = useRef(false);
+
+  useEffect(() => {
+    if (!transport || containerRegisteredRef.current) return;
+    if (!(controller instanceof IframeController)) return;
+
+    const control: RNWebViewControl = {
+      injectJavaScript: (script: string) => {
+        WebViewRef.current?.injectJavaScript?.(script);
+      },
+      loadUrl: (url: string) => {
+        // Schedule a render so the WebView's `source` prop updates.
+        setPendingUrl(url);
+      },
+      setVisible: () => {
+        // Visibility is owned by this component (modal/collapsed/inline) — the
+        // transport's setVisible() is informational.
+      },
+      unmount: () => {
+        setPendingUrl(null);
+      },
+    };
+    controller.setContainerElement(control as unknown as HTMLElement);
+    containerRegisteredRef.current = true;
+  }, [controller, transport]);
+
+  // Auto-login when configured for fullview.
+  useEffect(() => {
+    if (!controller) return;
+    const isFullview = inactiveView === "fullview";
+    const shouldAutoLogin =
+      (!isConnected &&
+        !isConnecting &&
+        !isDisconnected &&
+        !abstraxionError &&
+        idleView === "fullview") ||
+      (isDisconnected && !abstraxionError && (disconnectedView ?? idleView) === "fullview") ||
+      (!!abstraxionError && isFullview);
+    if (shouldAutoLogin) {
+      login().catch(() => undefined);
+    }
+  }, [
+    controller,
+    isConnected,
+    isConnecting,
+    isDisconnected,
+    abstraxionError,
+    idleView,
+    disconnectedView,
+    inactiveView,
+    login,
+  ]);
+
+  useImperativeHandle(forwardedRef, () => ({
+    reload: () => {
+      WebViewRef.current?.reload?.();
+    },
+  }));
+
+  const handleMessage = useCallback(
+    (event: { nativeEvent: { data: string } }) => {
+      transport?.handleWebViewMessage(event.nativeEvent.data);
+    },
+    [transport],
+  );
+
+  const handleLogin = useCallback(() => {
+    login().catch(() => undefined);
+  }, [login]);
+
+  if (!(controller instanceof IframeController)) {
+    return null;
+  }
+  if (!WebViewModule) {
+    return (
+      <View style={styles.errorBox}>
+        <Text style={styles.errorText}>
+          react-native-webview is required for embedded mode. Install it as a peer dep.
+        </Text>
+      </View>
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const WebView = WebViewModule.WebView as any;
+  const isInactive = !isConnected && !isConnecting;
+  const showButton =
+    (isInactive && inactiveView === "button") ||
+    (!!abstraxionError && inactiveView !== "fullview");
+  const collapse =
+    (isConnected && !isAwaitingApproval && connectedView === "hidden") ||
+    (isInactive && inactiveView !== "fullview") ||
+    (!!abstraxionError && inactiveView !== "fullview");
+
+  const showAsModal =
+    isConnected && isAwaitingApproval && approvalView === "modal";
+
+  const webViewElement =
+    pendingUrl && WebView ? (
+      <WebView
+        ref={WebViewRef}
+        source={{ uri: pendingUrl }}
+        onMessage={handleMessage}
+        javaScriptEnabled
+        domStorageEnabled
+        sharedCookiesEnabled
+        style={styles.webView}
+      />
+    ) : null;
+
+  return (
+    <>
+      {showButton && (
+        <Pressable onPress={handleLogin} style={styles.loginButton}>
+          <Text style={styles.loginButtonText}>{loginLabel}</Text>
+        </Pressable>
+      )}
+
+      {showAsModal ? (
+        <Modal
+          transparent
+          animationType="fade"
+          onRequestClose={() => controller.cancelApproval()}
+        >
+          <Pressable
+            style={styles.backdrop}
+            onPress={() => controller.cancelApproval()}
+          >
+            <Pressable style={styles.modalCard} onPress={(e) => e.stopPropagation()}>
+              {webViewElement}
+            </Pressable>
+          </Pressable>
+        </Modal>
+      ) : (
+        <View style={collapse ? collapsed : style}>{webViewElement}</View>
+      )}
+    </>
+  );
+});
+
+const styles = StyleSheet.create({
+  webView: { flex: 1 },
+  loginButton: {
+    backgroundColor: "#000",
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 24,
+    alignSelf: "flex-start",
+  },
+  loginButtonText: {
+    color: "#fff",
+    fontWeight: "600",
+  },
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modalCard: {
+    width: "90%",
+    height: "80%",
+    backgroundColor: "white",
+    borderRadius: 16,
+    overflow: "hidden",
+  },
+  errorBox: {
+    padding: 16,
+    backgroundColor: "#fee",
+  },
+  errorText: {
+    color: "#900",
+  },
+});

--- a/packages/abstraxion-react-native/src/components/AbstraxionEmbed.tsx
+++ b/packages/abstraxion-react-native/src/components/AbstraxionEmbed.tsx
@@ -158,7 +158,9 @@ export const AbstraxionEmbed = forwardRef<
         !isDisconnected &&
         !abstraxionError &&
         idleView === "fullview") ||
-      (isDisconnected && !abstraxionError && (disconnectedView ?? idleView) === "fullview") ||
+      (isDisconnected &&
+        !abstraxionError &&
+        (disconnectedView ?? idleView) === "fullview") ||
       (!!abstraxionError && isFullview);
     if (shouldAutoLogin) {
       login().catch(() => undefined);
@@ -199,7 +201,8 @@ export const AbstraxionEmbed = forwardRef<
     return (
       <View style={styles.errorBox}>
         <Text style={styles.errorText}>
-          react-native-webview is required for embedded mode. Install it as a peer dep.
+          react-native-webview is required for embedded mode. Install it as a
+          peer dep.
         </Text>
       </View>
     );
@@ -250,7 +253,10 @@ export const AbstraxionEmbed = forwardRef<
             style={styles.backdrop}
             onPress={() => controller.cancelApproval()}
           >
-            <Pressable style={styles.modalCard} onPress={(e) => e.stopPropagation()}>
+            <Pressable
+              style={styles.modalCard}
+              onPress={(e) => e.stopPropagation()}
+            >
               {webViewElement}
             </Pressable>
           </Pressable>

--- a/packages/abstraxion-react-native/src/hooks/__tests__/hooks.test.tsx
+++ b/packages/abstraxion-react-native/src/hooks/__tests__/hooks.test.tsx
@@ -46,6 +46,7 @@ import {
   CosmWasmClient,
   createSignerFromSigningFunction,
   GasPrice,
+  RedirectController,
 } from "@burnt-labs/abstraxion-js";
 import { AbstraxionContext } from "../../components/AbstraxionContext";
 import { useAbstraxionAccount } from "../useAbstraxionAccount";
@@ -58,26 +59,86 @@ type ContextValue = React.ContextType<typeof AbstraxionContext>;
 function createContextValue(
   overrides: Partial<ContextValue> = {},
 ): ContextValue {
+  // Build a runtime stub that mirrors `runtime.manageAuthenticators` /
+  // `runtime.createReadClient` / `runtime.createDirectSigningClient` semantics
+  // for the controller passed via overrides.
+  const controllerForRuntime =
+    overrides.controller ?? (undefined as unknown as ContextValue["controller"]);
+  const isSupported = controllerForRuntime instanceof RedirectController;
+  const overrideAuthMode = (overrides.authMode ?? "redirect") as
+    | "signer"
+    | "redirect"
+    | "embedded";
+  const overrideConnectionInfo = overrides.connectionInfo;
+  const overrideGranterAddress = overrides.granterAddress;
+  const overrideRpcUrl = overrides.rpcUrl ?? "https://rpc.test";
+  const runtime = {
+    isManageAuthSupported: isSupported,
+    manageAuthUnsupportedReason: isSupported
+      ? undefined
+      : "Manage authenticators is not supported in signer mode. Use popup, redirect, or embedded authentication to add or remove authenticators.",
+    manageAuthenticators: vi.fn(async (addr: string) => {
+      const ctrl = controllerForRuntime as
+        | { promptManageAuthenticators?: (addr: string) => Promise<void> }
+        | undefined;
+      if (ctrl && typeof ctrl.promptManageAuthenticators === "function") {
+        return ctrl.promptManageAuthenticators(addr);
+      }
+      throw new Error(
+        "Manage authenticators is not supported in signer mode. Use redirect or embedded authentication to add or remove authenticators.",
+      );
+    }),
+    // Mirror the real runtime's `createReadClient` / `createDirectSigningClient`
+    // surface so hook tests can assert against the same downstream mocks the
+    // production runtime would call.
+    createReadClient: vi.fn(async () => CosmWasmClient.connect(overrideRpcUrl)),
+    createDirectSigningClient: vi.fn(async () => {
+      if (overrideAuthMode === "signer") {
+        const info = overrideConnectionInfo as
+          | { signMessage: unknown; metadata?: Record<string, unknown> }
+          | undefined;
+        if (!info || !overrideGranterAddress) return undefined;
+        const meta = info.metadata ?? {};
+        createSignerFromSigningFunction({
+          smartAccountAddress: overrideGranterAddress,
+          authenticatorIndex: (meta.authenticatorIndex as number | undefined) ?? 0,
+          authenticatorType: meta.authenticatorType as never,
+          signMessage: info.signMessage as never,
+        });
+        return AAClient.connectWithSigner(overrideRpcUrl, signer as never, {
+          gasPrice: GasPrice.fromString("0.001uxion"),
+        });
+      }
+      // Redirect / embedded: production runtime returns a RequireSigningClient.
+      // Tests don't need the real implementation; a sentinel object is enough.
+      return { __mockRequireSigningClient: true } as never;
+    }),
+    subscribe: vi.fn(() => () => undefined),
+    subscribeApproval: vi.fn(() => () => undefined),
+    getApprovalState: vi.fn(() => false),
+    getState: vi.fn(),
+    initialize: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn(),
+    destroy: vi.fn(),
+    updateGetSignerConfig: vi.fn(),
+    controller: controllerForRuntime,
+    config: {} as unknown,
+    authMode: overrideAuthMode,
+  } as unknown as ContextValue["runtime"];
+
   return {
     isConnected: false,
-    setIsConnected: vi.fn(),
     isConnecting: false,
-    setIsConnecting: vi.fn(),
     isInitializing: false,
     isDisconnected: false,
+    isAwaitingApproval: false,
     isReturningFromAuth: false,
     isLoggingIn: false,
     abstraxionError: "",
-    setAbstraxionError: vi.fn(),
     abstraxionAccount: undefined,
-    setAbstraxionAccount: vi.fn(),
     granterAddress: "",
-    showModal: false,
-    setShowModal: vi.fn(),
-    setGranterAddress: vi.fn(),
     contracts: undefined,
-    dashboardUrl: "",
-    setDashboardUrl: vi.fn(),
     chainId: "xion-testnet-2",
     rpcUrl: "https://rpc.test",
     restUrl: "https://rest.test",
@@ -91,6 +152,7 @@ function createContextValue(
     authentication: { type: "redirect" },
     connectionInfo: undefined,
     controller: undefined,
+    runtime,
     login: vi.fn().mockResolvedValue(undefined),
     logout: vi.fn().mockResolvedValue(undefined),
     ...overrides,
@@ -178,7 +240,7 @@ describe("React Native hooks", () => {
     expect(result.current.error).toBeUndefined();
   });
 
-  it("useAbstraxionSigningClient reports unsupported requireAuth in redirect mode", async () => {
+  it("useAbstraxionSigningClient returns a direct signing client in redirect requireAuth mode", async () => {
     const { result } = renderHook(
       () => useAbstraxionSigningClient({ requireAuth: true }),
       {
@@ -191,10 +253,12 @@ describe("React Native hooks", () => {
       },
     );
 
+    // Runtime now produces a RequireSigningClient for redirect mode (Phase 9e
+    // unification — previously the RN hook fenced this off).
     await waitFor(() => {
-      expect(result.current.error).toContain("React Native signer mode");
+      expect(result.current.client).toBeDefined();
     });
-    expect(result.current.client).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
     expect(result.current.signArb).toBeUndefined();
   });
 

--- a/packages/abstraxion-react-native/src/hooks/__tests__/hooks.test.tsx
+++ b/packages/abstraxion-react-native/src/hooks/__tests__/hooks.test.tsx
@@ -63,7 +63,8 @@ function createContextValue(
   // `runtime.createReadClient` / `runtime.createDirectSigningClient` semantics
   // for the controller passed via overrides.
   const controllerForRuntime =
-    overrides.controller ?? (undefined as unknown as ContextValue["controller"]);
+    overrides.controller ??
+    (undefined as unknown as ContextValue["controller"]);
   const isSupported = controllerForRuntime instanceof RedirectController;
   const overrideAuthMode = (overrides.authMode ?? "redirect") as
     | "signer"
@@ -101,7 +102,8 @@ function createContextValue(
         const meta = info.metadata ?? {};
         createSignerFromSigningFunction({
           smartAccountAddress: overrideGranterAddress,
-          authenticatorIndex: (meta.authenticatorIndex as number | undefined) ?? 0,
+          authenticatorIndex:
+            (meta.authenticatorIndex as number | undefined) ?? 0,
           authenticatorType: meta.authenticatorType as never,
           signMessage: info.signMessage as never,
         });

--- a/packages/abstraxion-react-native/src/hooks/useAbstraxionClient.ts
+++ b/packages/abstraxion-react-native/src/hooks/useAbstraxionClient.ts
@@ -1,12 +1,15 @@
 import { useContext, useEffect, useState } from "react";
-import { CosmWasmClient, testnetChainInfo } from "@burnt-labs/abstraxion-js";
+import {
+  CosmWasmClient,
+  testnetChainInfo,
+} from "@burnt-labs/abstraxion-js";
 import { AbstraxionContext } from "../components/AbstraxionContext";
 
 export const useAbstraxionClient = (): {
   readonly client: CosmWasmClient | undefined;
   readonly error: Error | undefined;
 } => {
-  const { rpcUrl } = useContext(AbstraxionContext);
+  const { rpcUrl, runtime } = useContext(AbstraxionContext);
 
   const [abstractClient, setAbstractClient] = useState<
     CosmWasmClient | undefined
@@ -14,16 +17,16 @@ export const useAbstraxionClient = (): {
   const [error, setError] = useState<Error | undefined>(undefined);
 
   useEffect(() => {
+    let cancelled = false;
     async function getClient(): Promise<void> {
       try {
         setError(undefined);
-        const client = await CosmWasmClient.connect(
-          // Should be set in the context but defaulting here just in case
-          rpcUrl || testnetChainInfo.rpc,
-        );
-
-        setAbstractClient(client);
+        const client = runtime
+          ? await runtime.createReadClient()
+          : await CosmWasmClient.connect(rpcUrl || testnetChainInfo.rpc);
+        if (!cancelled) setAbstractClient(client);
       } catch (err) {
+        if (cancelled) return;
         const errorMessage = err instanceof Error ? err.message : String(err);
         setError(
           new Error(
@@ -34,8 +37,11 @@ export const useAbstraxionClient = (): {
       }
     }
 
-    getClient();
-  }, [rpcUrl]);
+    void getClient();
+    return () => {
+      cancelled = true;
+    };
+  }, [rpcUrl, runtime]);
 
   return {
     client: abstractClient,

--- a/packages/abstraxion-react-native/src/hooks/useAbstraxionClient.ts
+++ b/packages/abstraxion-react-native/src/hooks/useAbstraxionClient.ts
@@ -1,8 +1,5 @@
 import { useContext, useEffect, useState } from "react";
-import {
-  CosmWasmClient,
-  testnetChainInfo,
-} from "@burnt-labs/abstraxion-js";
+import { CosmWasmClient, testnetChainInfo } from "@burnt-labs/abstraxion-js";
 import { AbstraxionContext } from "../components/AbstraxionContext";
 
 export const useAbstraxionClient = (): {

--- a/packages/abstraxion-react-native/src/hooks/useAbstraxionSigningClient.ts
+++ b/packages/abstraxion-react-native/src/hooks/useAbstraxionSigningClient.ts
@@ -1,24 +1,30 @@
-import { useContext, useEffect, useState } from "react";
 import {
-  AAClient,
-  createSignerFromSigningFunction,
-} from "@burnt-labs/abstraxion-js";
-import type {
-  AuthenticatorType,
-  SigningClient,
-  SignResult,
-} from "@burnt-labs/abstraxion-js";
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { RedirectController } from "@burnt-labs/abstraxion-js";
+import type { SigningClient, SignResult } from "@burnt-labs/abstraxion-js";
 import { AbstraxionContext } from "../components/AbstraxionContext";
 
+/**
+ * Options for `useAbstraxionSigningClient`.
+ */
 export interface UseAbstraxionSigningClientOptions {
   /**
-   * When true, returns a direct signing client where the active RN auth mode
-   * supports direct signing. Signer mode can provide `AAClient`; redirect mode
-   * currently supports session-key signing only in React Native.
+   * When true, returns a direct signing client (signer mode → AAClient,
+   * redirect/embedded → RequireSigningClient mediated by the dashboard).
+   * When false/undefined, returns the GranteeSignerClient for session-key
+   * signing (gasless, no popup).
    */
   requireAuth?: boolean;
 }
 
+/**
+ * Return type for `useAbstraxionSigningClient`.
+ */
 export interface UseAbstraxionSigningClientReturn {
   readonly client: SigningClient | undefined;
   readonly signArb:
@@ -26,87 +32,84 @@ export interface UseAbstraxionSigningClientReturn {
     | undefined;
   readonly rpcUrl: string;
   readonly error: string | undefined;
+  /**
+   * Result from a redirect signing flow (populated after returning from the
+   * dashboard). Null when no result is pending or not in redirect mode.
+   */
   readonly signResult: SignResult | null;
+  /** Clear the signResult after consuming it. */
   readonly clearSignResult: (() => void) | undefined;
 }
 
+/**
+ * Hook to get a signing client for transactions.
+ *
+ * Direct-signing client construction is delegated to
+ * `runtime.createDirectSigningClient()`, which covers signer / redirect /
+ * embedded modes with a single async call. The hook itself only mirrors the
+ * resulting promise into React state and subscribes to the redirect-mode
+ * `signResult` store.
+ */
 export const useAbstraxionSigningClient = (
   options?: UseAbstraxionSigningClientOptions,
 ): UseAbstraxionSigningClientReturn => {
   const {
     abstraxionAccount,
     authMode,
-    connectionInfo,
-    gasPrice,
+    controller,
     granterAddress,
     rpcUrl,
-    signingClient,
+    runtime,
+    signingClient: signingClientFromState,
   } = useContext(AbstraxionContext);
 
   const requireAuth = options?.requireAuth ?? false;
-  const [aaClient, setAaClient] = useState<AAClient | undefined>(undefined);
+
+  const [directClient, setDirectClient] = useState<SigningClient | undefined>(
+    undefined,
+  );
   const [error, setError] = useState<string | undefined>(undefined);
 
+  const redirectController =
+    controller instanceof RedirectController ? controller : undefined;
+  const signResult = useSyncExternalStore(
+    (cb) => redirectController?.signResult.subscribe(cb) ?? (() => undefined),
+    () => redirectController?.signResult.snapshot() ?? null,
+    () => null,
+  );
+  const clearSignResult = useCallback(() => {
+    redirectController?.signResult.clear();
+  }, [redirectController]);
+
   useEffect(() => {
-    if (!requireAuth) {
-      setAaClient(undefined);
+    if (!requireAuth || !runtime) {
+      setDirectClient(undefined);
       setError(undefined);
       return;
     }
 
-    if (authMode !== "signer") {
-      setAaClient(undefined);
-      setError(
-        "Direct signing with requireAuth is only supported in React Native signer mode. Redirect mode supports session-key signing only.",
-      );
-      return;
-    }
-
-    if (!connectionInfo) {
-      setAaClient(undefined);
-      setError(
-        "Direct signing requires an active signer connection. Please ensure you are logged in.",
-      );
-      return;
-    }
-
-    if (!granterAddress) {
-      setAaClient(undefined);
+    // Signer mode AAClient construction needs a connected account. Surface a
+    // friendly error rather than a raw runtime throw.
+    if (authMode === "signer" && !granterAddress) {
+      setDirectClient(undefined);
       setError(
         "Direct signing requires a connected account. Please ensure you are logged in.",
       );
       return;
     }
 
-    const createClient = async (): Promise<void> => {
-      try {
-        const authenticatorType = connectionInfo.metadata
-          ?.authenticatorType as AuthenticatorType;
-        const authenticatorIndex =
-          connectionInfo.metadata?.authenticatorIndex ?? 0;
-
-        if (!authenticatorType) {
-          throw new Error(
-            "Authenticator type not available in connection info",
-          );
-        }
-
-        const signer = createSignerFromSigningFunction({
-          smartAccountAddress: granterAddress,
-          authenticatorIndex,
-          authenticatorType,
-          signMessage: connectionInfo.signMessage,
-        });
-
-        const client = await AAClient.connectWithSigner(rpcUrl, signer, {
-          gasPrice,
-        });
-
-        setAaClient(client);
+    let cancelled = false;
+    runtime
+      .createDirectSigningClient()
+      .then((client) => {
+        if (cancelled) return;
+        setDirectClient(client);
         setError(undefined);
-      } catch (err) {
+      })
+      .catch((err) => {
+        if (cancelled) return;
         console.error(
-          "[useAbstraxionSigningClient] Error creating AAClient:",
+          "[useAbstraxionSigningClient] createDirectSigningClient failed:",
           err,
         );
         setError(
@@ -114,16 +117,27 @@ export const useAbstraxionSigningClient = (
             ? err.message
             : "Failed to create direct signing client",
         );
-        setAaClient(undefined);
-      }
-    };
+        setDirectClient(undefined);
+      });
 
-    void createClient();
-  }, [authMode, connectionInfo, gasPrice, granterAddress, requireAuth, rpcUrl]);
+    return () => {
+      cancelled = true;
+    };
+  }, [requireAuth, runtime, authMode, granterAddress]);
 
   if (requireAuth) {
+    if (authMode === "redirect") {
+      return {
+        client: directClient,
+        signArb: undefined,
+        rpcUrl,
+        error,
+        signResult,
+        clearSignResult: signResult ? clearSignResult : undefined,
+      };
+    }
     return {
-      client: authMode === "signer" ? aaClient : undefined,
+      client: directClient,
       signArb: undefined,
       rpcUrl,
       error,
@@ -133,7 +147,7 @@ export const useAbstraxionSigningClient = (
   }
 
   return {
-    client: signingClient,
+    client: signingClientFromState,
     signArb: abstraxionAccount?.signArb,
     rpcUrl,
     error: undefined,

--- a/packages/abstraxion-react-native/src/hooks/useManageAuthenticators.ts
+++ b/packages/abstraxion-react-native/src/hooks/useManageAuthenticators.ts
@@ -3,46 +3,40 @@ import { RedirectController } from "@burnt-labs/abstraxion-js";
 import type { ManageAuthResult } from "@burnt-labs/abstraxion-js";
 import { AbstraxionContext } from "../components/AbstraxionContext";
 
-const signerUnsupportedReason =
-  "Manage authenticators is not supported in signer mode. Use redirect authentication to add or remove authenticators.";
-
 export interface UseManageAuthenticatorsReturn {
-  /** Open the manage-authenticators flow when supported. */
   manageAuthenticators: () => Promise<void>;
-  /** True when the current React Native authentication mode supports manage-authenticators. */
   isSupported: boolean;
-  /** Human-readable reason when `isSupported` is false. */
   unsupportedReason: string | undefined;
-  /**
-   * Populated after the dashboard manage-authenticators flow completes
-   * (Expo WebBrowser session resolves). Null until a result is available.
-   */
   manageAuthResult: ManageAuthResult | null;
-  /** Clear `manageAuthResult` once handled. */
   clearManageAuthResult: () => void;
 }
 
 export function useManageAuthenticators(): UseManageAuthenticatorsReturn {
-  const { controller, granterAddress } = useContext(AbstraxionContext);
+  const { runtime, controller, granterAddress } = useContext(AbstraxionContext);
 
-  const isRedirect = controller instanceof RedirectController;
-  const isSupported = isRedirect;
+  const isSupported = runtime?.isManageAuthSupported ?? false;
+  const unsupportedReason = isSupported
+    ? undefined
+    : (runtime?.manageAuthUnsupportedReason ??
+      "useManageAuthenticators: AbstraxionProvider is not mounted.");
 
   const manageAuthenticators = useCallback(async () => {
+    if (!runtime) {
+      throw new Error(
+        "useManageAuthenticators: AbstraxionProvider is not mounted.",
+      );
+    }
     if (!granterAddress) {
       throw new Error(
         "useManageAuthenticators: user is not connected. Call login() first.",
       );
     }
+    // The runtime throws `manageAuthUnsupportedReason` for non-supported modes.
+    return runtime.manageAuthenticators(granterAddress);
+  }, [runtime, granterAddress]);
 
-    if (controller instanceof RedirectController) {
-      await controller.promptManageAuthenticators(granterAddress);
-      return;
-    }
-
-    throw new Error(signerUnsupportedReason);
-  }, [controller, granterAddress]);
-
+  // Redirect mode stashes the manage-auth result via the strategy after
+  // WebBrowser resolves; subscribe so consumers see it.
   const manageAuthResult = useSyncExternalStore(
     (cb) =>
       controller instanceof RedirectController
@@ -64,7 +58,7 @@ export function useManageAuthenticators(): UseManageAuthenticatorsReturn {
   return {
     manageAuthenticators,
     isSupported,
-    unsupportedReason: isSupported ? undefined : signerUnsupportedReason,
+    unsupportedReason,
     manageAuthResult,
     clearManageAuthResult,
   };

--- a/packages/abstraxion-react-native/src/index.ts
+++ b/packages/abstraxion-react-native/src/index.ts
@@ -1,3 +1,13 @@
 export * from "./hooks";
-export * from "./strategies";
+export { ReactNativeStorageStrategy } from "./strategies/ReactNativeStorageStrategy";
+export { ReactNativeRedirectStrategy } from "./strategies/ReactNativeRedirectStrategy";
+export {
+  RNWebViewIframeTransport,
+  type RNWebViewControl,
+} from "./strategies/RNWebViewIframeTransport";
 export * from "./components/AbstraxionContext";
+export {
+  AbstraxionEmbed,
+  type AbstraxionEmbedHandle,
+  type AbstraxionEmbedProps,
+} from "./components/AbstraxionEmbed";

--- a/packages/abstraxion-react-native/src/strategies/RNWebViewIframeTransport.ts
+++ b/packages/abstraxion-react-native/src/strategies/RNWebViewIframeTransport.ts
@@ -1,0 +1,360 @@
+/**
+ * React Native implementation of `IframeTransportStrategy`.
+ *
+ * Mounts the dashboard inside a `react-native-webview` `<WebView>` and bridges
+ * SDK ↔ dashboard messages over `injectedJavaScript` + `onMessage`. The
+ * dashboard's existing `MessageChannel`-based protocol is preserved by
+ * synthesising a real `MessageChannel` *inside* the WebView's JS context (where
+ * the API is available natively) and forwarding the response back to native
+ * via `window.ReactNativeWebView.postMessage`.
+ *
+ * No dashboard-side protocol changes are required — the bridge is entirely
+ * SDK-side. See Phase 9b notes in `.docs/tasks/abstraxion_package_restructure.md`.
+ *
+ * The host `<AbstraxionEmbed>` component renders the actual `<WebView>` and
+ * calls `setContainer({ webViewRef, ... })` so the transport can drive it.
+ */
+
+import type {
+  IframeMountContext,
+  IframeTransportStrategy,
+} from "@burnt-labs/abstraxion-js";
+import { IframeMessageType } from "@burnt-labs/abstraxion-js";
+
+/**
+ * The host component (RN `<AbstraxionEmbed>`) supplies this control surface
+ * so the transport can drive the WebView without importing react-native-webview
+ * directly. This keeps the transport renderer-agnostic and avoids forcing a
+ * webview dependency on consumers who never use embedded mode.
+ */
+export interface RNWebViewControl {
+  /** Inject JavaScript into the live WebView. Returns when the eval is dispatched. */
+  injectJavaScript(script: string): void;
+  /** Replace the loaded URL — typically calls `setSource({ uri })` on the host. */
+  loadUrl(url: string): void;
+  /** Show / hide the WebView container. */
+  setVisible(visible: boolean): void;
+  /** Tear down the WebView. */
+  unmount(): void;
+}
+
+/**
+ * RPC envelope sent across the JS bridge.
+ */
+interface BridgeRequest {
+  kind: "request";
+  requestId: string;
+  type: string;
+  target: string;
+  payload: unknown;
+  origin: string;
+}
+interface BridgeResponse {
+  kind: "response";
+  requestId: string;
+  data: unknown;
+}
+interface BridgePush {
+  kind: "push";
+  data: { type?: string; [key: string]: unknown };
+}
+interface BridgeReady {
+  kind: "ready";
+}
+type BridgeMessage =
+  | BridgeRequest
+  | BridgeResponse
+  | BridgePush
+  | BridgeReady;
+
+const BRIDGE_INSTALL_SCRIPT = `(function() {
+  if (window.__abstraxionBridgeInstalled) return;
+  window.__abstraxionBridgeInstalled = true;
+
+  // Forward any postMessage the dashboard sends to its parent (IFRAME_READY,
+  // HARD_DISCONNECT, etc.). We route through window.parent.postMessage —
+  // overridden below — and via window.addEventListener("message") for safety.
+  var rnPost = function(payload) {
+    try {
+      window.ReactNativeWebView.postMessage(JSON.stringify(payload));
+    } catch (e) {
+      // No-op: WebView torn down between dispatch and post.
+    }
+  };
+
+  // Dashboard self-broadcasts IFRAME_READY / HARD_DISCONNECT to window.parent.
+  // In RN there is no real parent, so we monkey-patch window.parent.postMessage
+  // on the global scope so the existing dashboard code path works unchanged.
+  try {
+    Object.defineProperty(window, "parent", {
+      configurable: true,
+      get: function() {
+        return {
+          postMessage: function(data) {
+            rnPost({ kind: "push", data: data });
+          }
+        };
+      }
+    });
+  } catch (e) { /* fall back to message listener below */ }
+
+  // Some dashboard code paths post on window itself instead of window.parent.
+  window.addEventListener("message", function(e) {
+    // Skip messages we just delivered to window via dispatchEvent below
+    if (e && e.data && e.data.__abxFromNative) return;
+    rnPost({ kind: "push", data: e.data });
+  });
+
+  // Bridge: react to native-injected requests by synthesising a MessageChannel
+  // and dispatching the same MessageEvent shape the dashboard expects.
+  window.__abstraxionBridgeDispatch = function(envelope) {
+    try {
+      var channel = new MessageChannel();
+      channel.port1.onmessage = function(ev) {
+        rnPost({
+          kind: "response",
+          requestId: envelope.requestId,
+          data: ev.data
+        });
+      };
+      // Dashboard's IframeMessageHandler picks up the port from event.ports[0].
+      var msgEvent = new MessageEvent("message", {
+        data: { type: envelope.type, target: envelope.target, payload: envelope.payload, requestId: envelope.requestId, __abxFromNative: true },
+        origin: envelope.origin,
+        ports: [channel.port2]
+      });
+      window.dispatchEvent(msgEvent);
+    } catch (err) {
+      rnPost({ kind: "response", requestId: envelope.requestId, data: { success: false, error: String(err && err.message || err) } });
+    }
+  };
+
+  rnPost({ kind: "ready" });
+})();
+true;`;
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: unknown) => void;
+  timeoutHandle: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * `IframeTransportStrategy` implementation backed by a host-supplied WebView.
+ *
+ * The actual `<WebView>` element is rendered by the RN `<AbstraxionEmbed>`
+ * component; this strategy only drives it via the `RNWebViewControl` interface.
+ */
+export class RNWebViewIframeTransport implements IframeTransportStrategy {
+  private control: RNWebViewControl | null = null;
+  private mounted = false;
+  private origin: string | null = null;
+  private requestSeq = 0;
+  private pending = new Map<string, PendingRequest>();
+  private pushListeners = new Set<(data: unknown) => void>();
+  private readyResolvers: Array<() => void> = [];
+  private bridgeReady = false;
+
+  setContainer(container: unknown): void {
+    if (container === null) {
+      this.control = null;
+      return;
+    }
+    if (
+      !container ||
+      typeof (container as RNWebViewControl).injectJavaScript !== "function" ||
+      typeof (container as RNWebViewControl).loadUrl !== "function"
+    ) {
+      throw new TypeError(
+        "[RNWebViewIframeTransport] container must implement RNWebViewControl. " +
+          "Use the <AbstraxionEmbed> component from @burnt-labs/abstraxion-react-native, " +
+          "which constructs the control surface for you.",
+      );
+    }
+    this.control = container as RNWebViewControl;
+  }
+
+  hasContainer(): boolean {
+    return !!this.control;
+  }
+
+  isMounted(): boolean {
+    return this.mounted;
+  }
+
+  mount(context: IframeMountContext): void {
+    if (!this.control) {
+      throw new Error(
+        "RNWebViewIframeTransport: <AbstraxionEmbed> has not been mounted yet. " +
+          "Render <AbstraxionEmbed /> before calling login() in embedded mode.",
+      );
+    }
+    this.origin = context.origin;
+    this.mounted = true;
+    this.bridgeReady = false;
+    this.control.loadUrl(context.url);
+    // Inject the bridge once the WebView's load handler runs.
+    this.control.injectJavaScript(BRIDGE_INSTALL_SCRIPT);
+  }
+
+  navigate(url: string): void {
+    if (this.control) {
+      this.bridgeReady = false;
+      this.control.loadUrl(url);
+      this.control.injectJavaScript(BRIDGE_INSTALL_SCRIPT);
+    }
+  }
+
+  waitForReady(timeoutMs: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const idx = this.readyResolvers.indexOf(resolver);
+        if (idx >= 0) this.readyResolvers.splice(idx, 1);
+        reject(new Error(`WebView did not become ready within ${timeoutMs}ms`));
+      }, timeoutMs);
+      const resolver = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+      this.readyResolvers.push(resolver);
+    });
+  }
+
+  sendRequest<TRequest, TResponse>(
+    type: IframeMessageType,
+    payload: TRequest,
+    timeoutMs: number,
+  ): Promise<TResponse> {
+    if (!this.control || !this.mounted) {
+      return Promise.reject(
+        new Error(
+          "RNWebViewIframeTransport: WebView is not mounted. Connect first before sending requests.",
+        ),
+      );
+    }
+    if (!this.origin) {
+      return Promise.reject(
+        new Error("RNWebViewIframeTransport: origin is not set."),
+      );
+    }
+
+    const requestId = `rn_${++this.requestSeq}_${Date.now()}`;
+    const envelope: BridgeRequest = {
+      kind: "request",
+      requestId,
+      type: type as unknown as string,
+      target: "XION_IFRAME",
+      payload,
+      origin: this.origin,
+    };
+
+    return new Promise<TResponse>((resolve, reject) => {
+      const timeoutHandle = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(new Error(`Request timeout: ${type}`));
+      }, timeoutMs);
+
+      this.pending.set(requestId, {
+        resolve: (data) => {
+          const response = data as
+            | { success: true; data: TResponse }
+            | { success: false; error: string };
+          if (response && response.success) {
+            resolve(response.data);
+          } else {
+            reject(
+              new Error(
+                (response && response.error) || `Request failed: ${type}`,
+              ),
+            );
+          }
+        },
+        reject,
+        timeoutHandle,
+      });
+
+      // JSON.stringify already escapes the few characters dangerous in a JS
+      // expression context (control chars, line/paragraph separators). The
+      // result is a valid JS object literal interpolated directly below.
+      const json = JSON.stringify(envelope);
+      this.control!.injectJavaScript(
+        `window.__abstraxionBridgeDispatch && window.__abstraxionBridgeDispatch(${json}); true;`,
+      );
+    });
+  }
+
+  onPushMessage(listener: (data: unknown) => void): () => void {
+    this.pushListeners.add(listener);
+    return () => this.pushListeners.delete(listener);
+  }
+
+  setVisible(visible: boolean): void {
+    this.control?.setVisible(visible);
+  }
+
+  unmount(): void {
+    this.mounted = false;
+    this.bridgeReady = false;
+    this.origin = null;
+    for (const [, request] of this.pending) {
+      clearTimeout(request.timeoutHandle);
+      request.reject(new Error("WebView unmounted"));
+    }
+    this.pending.clear();
+    this.readyResolvers.length = 0;
+    this.pushListeners.clear();
+    this.control?.unmount();
+  }
+
+  /**
+   * Called by the host `<AbstraxionEmbed>` component on every `onMessage`
+   * event from the WebView. Routes responses to pending requests, and
+   * dispatches push events to subscribers.
+   */
+  handleWebViewMessage(raw: string): void {
+    let parsed: BridgeMessage;
+    try {
+      parsed = JSON.parse(raw) as BridgeMessage;
+    } catch {
+      return;
+    }
+
+    if (parsed.kind === "ready") {
+      this.bridgeReady = true;
+      // The bridge is ready; the dashboard's IFRAME_READY pushes will arrive
+      // separately as `push` messages.
+      return;
+    }
+
+    if (parsed.kind === "response") {
+      const request = this.pending.get(parsed.requestId);
+      if (!request) return;
+      this.pending.delete(parsed.requestId);
+      clearTimeout(request.timeoutHandle);
+      request.resolve(parsed.data);
+      return;
+    }
+
+    if (parsed.kind === "push") {
+      const data = parsed.data;
+      if (!data || typeof data.type !== "string") return;
+
+      if (data.type === "IFRAME_READY") {
+        const resolvers = this.readyResolvers.splice(0);
+        resolvers.forEach((r) => r());
+        return;
+      }
+
+      // Match BrowserIframeTransportStrategy: only surface push events the
+      // controller actually handles. Anything else is bridge noise.
+      if (data.type === "HARD_DISCONNECT" || data.type === "DISCONNECT") {
+        this.pushListeners.forEach((listener) => listener(data));
+      }
+    }
+  }
+
+  /** True after the bridge install script has confirmed it is loaded. */
+  get isBridgeReady(): boolean {
+    return this.bridgeReady;
+  }
+}

--- a/packages/abstraxion-react-native/src/strategies/RNWebViewIframeTransport.ts
+++ b/packages/abstraxion-react-native/src/strategies/RNWebViewIframeTransport.ts
@@ -61,11 +61,7 @@ interface BridgePush {
 interface BridgeReady {
   kind: "ready";
 }
-type BridgeMessage =
-  | BridgeRequest
-  | BridgeResponse
-  | BridgePush
-  | BridgeReady;
+type BridgeMessage = BridgeRequest | BridgeResponse | BridgePush | BridgeReady;
 
 const BRIDGE_INSTALL_SCRIPT = `(function() {
   if (window.__abstraxionBridgeInstalled) return;

--- a/packages/abstraxion-react-native/src/strategies/ReactNativeRedirectStrategy.ts
+++ b/packages/abstraxion-react-native/src/strategies/ReactNativeRedirectStrategy.ts
@@ -1,49 +1,16 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as WebBrowser from "expo-web-browser";
 import * as Linking from "expo-linking";
-import type {
-  RedirectStrategy,
-  StorageStrategy,
-} from "@burnt-labs/abstraxion-js";
+import type { RedirectStrategy } from "@burnt-labs/abstraxion-js";
 
 /**
- * React Native implementation of the StorageStrategy using AsyncStorage
- */
-export class ReactNativeStorageStrategy implements StorageStrategy {
-  async getItem(key: string): Promise<string | null> {
-    try {
-      return await AsyncStorage.getItem(key);
-    } catch (error) {
-      console.error("AsyncStorage getItem error:", error);
-      return null;
-    }
-  }
-
-  async setItem(key: string, value: string): Promise<void> {
-    try {
-      await AsyncStorage.setItem(key, value);
-    } catch (error) {
-      console.error("AsyncStorage setItem error:", error);
-    }
-  }
-
-  async removeItem(key: string): Promise<void> {
-    try {
-      await AsyncStorage.removeItem(key);
-    } catch (error) {
-      console.error("AsyncStorage removeItem error:", error);
-    }
-  }
-}
-
-/**
- * React Native implementation of the RedirectStrategy using Expo WebBrowser.
+ * React Native implementation of `RedirectStrategy` using Expo WebBrowser.
  *
  * After a successful WebBrowser auth session, the result URL's query params
- * are stashed on the strategy so subsequent `getUrlParameter`/`cleanUrlParameters`
- * calls can read and clear them. This lets RedirectController's
- * `detectSignResult` / `detectManageAuthResult` flows work after
- * `redirect()` resolves, the same way they work after a browser page reload.
+ * are stashed on the strategy so subsequent `getUrlParameter` /
+ * `cleanUrlParameters` calls can read and clear them. This lets
+ * `RedirectController`'s `detectSignResult` / `detectManageAuthResult` flows
+ * work after `redirect()` resolves, the same way they work after a browser
+ * page reload.
  */
 export class ReactNativeRedirectStrategy implements RedirectStrategy {
   private redirectCallback?: (params: { granter?: string | null }) => void;

--- a/packages/abstraxion-react-native/src/strategies/ReactNativeStorageStrategy.ts
+++ b/packages/abstraxion-react-native/src/strategies/ReactNativeStorageStrategy.ts
@@ -1,0 +1,32 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { StorageStrategy } from "@burnt-labs/abstraxion-js";
+
+/**
+ * React Native implementation of `StorageStrategy` backed by AsyncStorage.
+ */
+export class ReactNativeStorageStrategy implements StorageStrategy {
+  async getItem(key: string): Promise<string | null> {
+    try {
+      return await AsyncStorage.getItem(key);
+    } catch (error) {
+      console.error("AsyncStorage getItem error:", error);
+      return null;
+    }
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    try {
+      await AsyncStorage.setItem(key, value);
+    } catch (error) {
+      console.error("AsyncStorage setItem error:", error);
+    }
+  }
+
+  async removeItem(key: string): Promise<void> {
+    try {
+      await AsyncStorage.removeItem(key);
+    } catch (error) {
+      console.error("AsyncStorage removeItem error:", error);
+    }
+  }
+}

--- a/packages/abstraxion-react-native/src/strategies/__tests__/ReactNativeRedirectStrategy.test.ts
+++ b/packages/abstraxion-react-native/src/strategies/__tests__/ReactNativeRedirectStrategy.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ReactNativeRedirectStrategy } from "../index";
+import { ReactNativeRedirectStrategy } from "../ReactNativeRedirectStrategy";
 
 vi.mock("@react-native-async-storage/async-storage", () => ({
   default: {

--- a/packages/abstraxion-react/src/AbstraxionProvider.tsx
+++ b/packages/abstraxion-react/src/AbstraxionProvider.tsx
@@ -1,28 +1,29 @@
 import type { ReactNode } from "react";
-import { createContext, useCallback, useEffect, useState, useRef } from "react";
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import {
   AccountStateGuards,
-  BrowserRedirectStrategy,
-  BrowserStorageStrategy,
-  createController,
+  createAbstraxionRuntime,
   extractIndexerAuthToken,
-  IframeController,
-  PopupController,
   RedirectController,
   SignerController,
-  normalizeAbstraxionConfig,
 } from "@burnt-labs/abstraxion-js";
 import type {
   AbstraxionConfig,
+  AbstraxionRuntime,
   AuthenticationConfig,
   ContractGrantDescription,
   Controller,
   ConnectorConnectionResult,
   GranteeSignerClient,
-  NormalizedAbstraxionConfig,
   SignArbSecp256k1HdWallet,
   SpendLimit,
-  AccountState,
 } from "@burnt-labs/abstraxion-js";
 
 export type {
@@ -65,18 +66,20 @@ export interface AbstraxionContextProps {
   authentication?: AuthenticationConfig;
 
   /**
-   * Connection info for direct signing (signer mode only)
-   * Contains signMessage function and authenticator metadata
-   * Used by useAbstraxionSigningClient({ requireAuth: true })
+   * Connection info for direct signing (signer mode only).
+   * Used by useAbstraxionSigningClient({ requireAuth: true }) and (today)
+   * still surfaced for backwards-compatible escape-hatch usage.
    */
   connectionInfo?: ConnectorConnectionResult;
 
-  /**
-   * The active controller instance.
-   * Hooks use instanceof narrowing to access mode-specific capabilities
-   * (e.g. PopupController.promptSignAndBroadcast for direct signing in popup mode).
-   */
+  /** The active controller — escape hatch for advanced flows. */
   controller?: Controller;
+
+  /**
+   * Active framework-agnostic runtime. Hooks call into this instead of
+   * narrowing controllers themselves; keeps the React layer thin.
+   */
+  runtime?: AbstraxionRuntime;
 
   // Actions
   logout: () => Promise<void>;
@@ -88,7 +91,6 @@ export interface AbstraxionContextProps {
  * All functions throw errors to catch improper usage
  */
 const defaultContextValue: AbstraxionContextProps = {
-  // State - all false/empty until provider mounts
   isConnected: false,
   isConnecting: false,
   isInitializing: true,
@@ -101,7 +103,6 @@ const defaultContextValue: AbstraxionContextProps = {
   granterAddress: "",
   signingClient: undefined,
 
-  // Config - empty defaults (will be overridden by provider)
   chainId: "",
   rpcUrl: "",
   restUrl: "",
@@ -115,13 +116,12 @@ const defaultContextValue: AbstraxionContextProps = {
   indexerAuthToken: undefined,
   treasuryIndexerUrl: undefined,
 
-  // Authentication
   authMode: "redirect",
   authentication: undefined,
   connectionInfo: undefined,
   controller: undefined,
+  runtime: undefined,
 
-  // Actions - throw errors if called before provider mounts
   logout: async () => {
     throw new Error(
       "AbstraxionContext: logout() called before provider mounted. Wrap your component tree with <AbstraxionProvider>.",
@@ -144,162 +144,68 @@ export function AbstraxionProvider({
   children: ReactNode;
   config: AbstraxionConfig;
 }): JSX.Element {
-  // Normalize config synchronously - fills in defaults based on chainId
-  const normalizedConfig = normalizeAbstraxionConfig(config);
+  // Construct the runtime once. Strategies default to browser inside the
+  // runtime — no need to pass them explicitly here.
+  // autoInitialize is delayed so the first useSyncExternalStore snapshot is
+  // captured before any synchronous "INITIALIZE → CONNECTED" transition.
+  const runtimeRef = useRef<AbstraxionRuntime | null>(null);
+  if (!runtimeRef.current) {
+    runtimeRef.current = createAbstraxionRuntime(config, {
+      autoInitialize: false,
+    });
+  }
+  const runtime = runtimeRef.current;
+  const controller = runtime.controller;
+  const normalizedConfig = runtime.config;
+  const authMode = runtime.authMode;
 
-  // Use refs to persist controller and config across renders:
-  // - controllerRef: Stores controller instance (created once, reused)
-  // - configRef: Stores previous config to detect getSignerConfig function reference changes
-  // When external auth providers (e.g., Turnkey) become ready after initial render,
-  // they provide a new getSignerConfig function that must be updated in the controller
-  const controllerRef = useRef<Controller | null>(null);
-  const configRef = useRef<NormalizedAbstraxionConfig>(normalizedConfig);
+  // Update dynamic getSignerConfig when consumers swap in a new authenticated
+  // function (Turnkey, Privy, etc. become ready after first render). Run as an
+  // effect so the controller mutation happens post-commit.
+  const incomingSignerConfig =
+    config.authentication?.type === "signer"
+      ? config.authentication.getSignerConfig
+      : undefined;
+  useEffect(() => {
+    if (incomingSignerConfig) {
+      runtime.updateGetSignerConfig(incomingSignerConfig);
+    }
+  }, [runtime, incomingSignerConfig]);
 
-  // Capture previous config BEFORE updating configRef (for comparison)
-  const previousConfig = configRef.current;
-
-  // Extract values from normalized config
-  const {
-    chainId,
-    rpcUrl,
-    restUrl,
-    gasPrice,
-    contracts,
-    stake = false,
-    bank,
-    treasury,
-    feeGranter,
-    authentication,
-  } = normalizedConfig;
-
-  // Get indexer and treasuryIndexer from signer auth if available, otherwise undefined
   const indexer =
-    authentication?.type === "signer" ? authentication.indexer : undefined;
+    normalizedConfig.authentication?.type === "signer"
+      ? normalizedConfig.authentication.indexer
+      : undefined;
   const treasuryIndexer =
-    authentication?.type === "signer"
-      ? authentication.treasuryIndexer
+    normalizedConfig.authentication?.type === "signer"
+      ? normalizedConfig.authentication.treasuryIndexer
       : undefined;
 
-  if (!controllerRef.current) {
-    // First render: Create controller with normalized config
-    controllerRef.current = createController(normalizedConfig, {
-      storageStrategy: new BrowserStorageStrategy(),
-      redirectStrategy: new BrowserRedirectStrategy(),
-    });
-    configRef.current = normalizedConfig;
-  } else {
-    // Subsequent renders: Update controller's getSignerConfig if function reference changed
-    // This handles the case where external auth providers (e.g., Turnkey) become ready
-    // after initial render and provide a new authenticated getSignerConfig function
-    const isSignerMode =
-      previousConfig.authentication?.type === "signer" &&
-      authentication?.type === "signer";
-    const isSignerController =
-      controllerRef.current instanceof SignerController;
-    const hasSignerConfigChanged =
-      previousConfig.authentication?.type === "signer" &&
-      authentication?.type === "signer" &&
-      previousConfig.authentication.getSignerConfig !==
-        authentication.getSignerConfig;
-
-    if (isSignerMode && isSignerController && hasSignerConfigChanged) {
-      // TypeScript: We've verified it's a SignerController above
-      (controllerRef.current as SignerController).updateGetSignerConfig(
-        authentication.getSignerConfig,
-      );
-    }
-
-    // Update configRef for next render's comparison
-    configRef.current = normalizedConfig;
-  }
-
-  // Always start with controller's initializing state this ensures UI immediately shows loading state and doesn't assume readiness
-  const controller = controllerRef.current;
-
-  // Derive authMode from the actual controller type, not from normalizedConfig.
-  // normalizeAbstraxionConfig + resolveAutoAuth runs on every render and can return
-  // different results between SSR and client (window undefined → defined), or when
-  // the viewport changes (e.g. isMobileOrStandalone flips on resize). The controller
-  // is created once (via ref) and never replaced, so authMode must stay in sync with it.
-  const authMode: "signer" | "redirect" | "embedded" | "popup" =
-    controller instanceof PopupController
-      ? "popup"
-      : controller instanceof RedirectController
-        ? "redirect"
-        : controller instanceof IframeController
-          ? "embedded"
-          : "signer";
-
-  const [controllerState, setControllerState] = useState<AccountState>(
-    controller.getState(),
+  const controllerState = useSyncExternalStore(
+    runtime.subscribe,
+    runtime.getState,
+    runtime.getState,
   );
 
-  // Track whether a requireAuth signing request is pending (iframe needs to be visible)
-  const [isAwaitingApproval, setIsAwaitingApproval] = useState(false);
+  const isAwaitingApproval = useSyncExternalStore(
+    runtime.subscribeApproval,
+    runtime.getApprovalState,
+    runtime.getApprovalState,
+  );
 
-  // TODO: Potentially put in a useEffect with empty dependency array to check if we're returning from auth redirect and if so, transition to connecting state
-  // To keep it clean this is all handled in the controller for now, this means there is a short INIT window for redirect mode
-
-  // Controller handles all state transitions including detecting redirect callbacks
+  // Initialize once and clean up on unmount.
   useEffect(() => {
-    const unsubscribe = controller.subscribe((newState) => {
-      setControllerState(newState);
-    });
-
-    // Subscribe to awaitingApproval changes (iframe mode only)
-    let unsubscribeApproval: (() => void) | undefined;
-    if (controller instanceof IframeController) {
-      unsubscribeApproval = controller.subscribeApproval(setIsAwaitingApproval);
-    }
-
-    // Initialize controller (restores session, checks redirect callbacks, etc.)
-    controller.initialize().catch((error) => {
-      // Initialization errors are handled by controller's state machine.
-      // Error state will be reflected in isError/abstraxionError context values.
-      // Log here for debugging in case the state machine didn't capture it.
+    runtime.initialize().catch((error) => {
       console.error(
         "[AbstraxionProvider] Controller initialization failed:",
         error,
       );
     });
-
     return () => {
-      unsubscribe(); // Cleanup subscription
-      unsubscribeApproval?.();
-      controller.destroy();
+      runtime.destroy();
     };
-  }, [controller]);
+  }, [runtime]);
 
-  // Dev warning: no grants configured — valid for direct-signing (requireAuth) flows,
-  // but unusual for popup/redirect/embedded modes.
-  useEffect(() => {
-    if (process.env.NODE_ENV !== "production") {
-      const hasGrants =
-        !!treasury ||
-        (contracts && contracts.length > 0) ||
-        !!stake ||
-        (bank && bank.length > 0);
-
-      const isDashboardMode =
-        authMode === "popup" ||
-        authMode === "redirect" ||
-        authMode === "embedded";
-
-      if (!hasGrants && isDashboardMode) {
-        console.warn(
-          "[AbstraxionProvider] No grants configured (treasury, contracts, stake, or bank). " +
-            "In popup/redirect/embedded modes the user will authenticate and get a session key, " +
-            "but no on-chain permissions will be granted to it. " +
-            "This is intentional if you are using requireAuth (direct signing), where the user " +
-            "signs transactions directly from their meta-account rather than via a session key. " +
-            "If you expected grant-based signing, add a `treasury` address or legacy grant config.",
-        );
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Run once on mount — config is stable after normalizeAbstraxionConfig
-
-  // Map state machine state to context props - ALL loading states come from state machine
   const isInitializing = AccountStateGuards.isInitializing(controllerState);
   const isConnecting =
     AccountStateGuards.isConnecting(controllerState) ||
@@ -307,20 +213,17 @@ export function AbstraxionProvider({
   const isConnected = AccountStateGuards.isConnected(controllerState);
   const isDisconnected = AccountStateGuards.isDisconnected(controllerState);
   const isError = AccountStateGuards.isError(controllerState);
-
-  // Derive isLoggingIn from connecting state (user actively logging in)
-  // This is true when connecting but not initializing (i.e., user-initiated connection)
   const isLoggingIn = isConnecting && !isInitializing;
 
-  // Derive isReturningFromAuth from state machine + controller check
-  // True when: in redirect mode, state is connecting, and URL has granted=true
+  // Redirect mode: surface the "we're back from the dashboard" state so the
+  // host can render an interstitial instead of flicker-rendering the
+  // disconnected view while the orchestrator finishes restoring.
   const isReturningFromAuth =
     authMode === "redirect" &&
     isConnecting &&
     controller instanceof RedirectController &&
     controller.isReturningFromRedirect();
 
-  // set the return values from the controller state
   const abstraxionAccount = isConnected
     ? controllerState.account.keypair
     : undefined;
@@ -330,66 +233,78 @@ export function AbstraxionProvider({
   const signingClient = isConnected ? controllerState.signingClient : undefined;
   const abstraxionError = isError ? controllerState.error : "";
 
-  // Get connection info from SignerController for direct signing
-  // Only available in signer mode when connected
   const connectionInfo =
-    isConnected &&
-    controller instanceof SignerController &&
-    controller.getConnectionInfo
-      ? controller.getConnectionInfo()
+    isConnected && controller instanceof SignerController
+      ? controller.getConnectionInfo?.()
       : undefined;
 
-  const login = useCallback(async () => {
-    // Login function - delegates to controller who handles errors
-    await controller.connect();
-  }, [controller]);
+  const login = useCallback(() => runtime.login(), [runtime]);
+  const logout = useCallback(() => runtime.logout(), [runtime]);
 
-  const logout = useCallback(async () => {
-    // Logout function - delegates to controller who handles errors
-    await controller.disconnect();
-  }, [controller]);
+  // Memoize the provider value so descendants don't re-render on unrelated
+  // state ticks.
+  const contextValue = useMemo<AbstraxionContextProps>(
+    () => ({
+      isConnected,
+      isConnecting,
+      isInitializing,
+      isDisconnected,
+      isAwaitingApproval,
+      isReturningFromAuth,
+      isLoggingIn,
+      abstraxionError,
+      abstraxionAccount,
+      granterAddress,
+      signingClient,
+
+      chainId: normalizedConfig.chainId,
+      rpcUrl: normalizedConfig.rpcUrl,
+      restUrl: normalizedConfig.restUrl,
+      gasPrice: normalizedConfig.gasPrice,
+      contracts: normalizedConfig.contracts,
+      stake: normalizedConfig.stake ?? false,
+      bank: normalizedConfig.bank,
+      treasury: normalizedConfig.treasury,
+      feeGranter: normalizedConfig.feeGranter,
+      indexerUrl: indexer?.url,
+      indexerAuthToken: extractIndexerAuthToken(indexer),
+      treasuryIndexerUrl: treasuryIndexer?.url,
+
+      authMode,
+      authentication: normalizedConfig.authentication,
+      connectionInfo,
+      controller,
+      runtime,
+
+      login,
+      logout,
+    }),
+    [
+      isConnected,
+      isConnecting,
+      isInitializing,
+      isDisconnected,
+      isAwaitingApproval,
+      isReturningFromAuth,
+      isLoggingIn,
+      abstraxionError,
+      abstraxionAccount,
+      granterAddress,
+      signingClient,
+      normalizedConfig,
+      indexer,
+      treasuryIndexer,
+      authMode,
+      connectionInfo,
+      controller,
+      runtime,
+      login,
+      logout,
+    ],
+  );
 
   return (
-    <AbstraxionContext.Provider
-      value={{
-        // State from controller's state machine
-        isConnected,
-        isConnecting,
-        isInitializing,
-        isDisconnected,
-        isAwaitingApproval,
-        isReturningFromAuth,
-        isLoggingIn,
-        abstraxionError,
-        abstraxionAccount,
-        granterAddress,
-        signingClient,
-
-        // Config
-        chainId,
-        rpcUrl,
-        restUrl,
-        gasPrice,
-        contracts,
-        stake,
-        bank,
-        treasury,
-        feeGranter,
-        indexerUrl: indexer?.url,
-        indexerAuthToken: extractIndexerAuthToken(indexer),
-        treasuryIndexerUrl: treasuryIndexer?.url,
-
-        // Authentication
-        authMode,
-        authentication,
-        connectionInfo,
-        controller,
-
-        // Actions
-        login,
-        logout,
-      }}
-    >
+    <AbstraxionContext.Provider value={contextValue}>
       {children}
     </AbstraxionContext.Provider>
   );

--- a/packages/abstraxion-react/src/hooks/__tests__/useManageAuthenticators.test.ts
+++ b/packages/abstraxion-react/src/hooks/__tests__/useManageAuthenticators.test.ts
@@ -71,8 +71,35 @@ function buildContext(
   controller: unknown,
   granterAddress: string | null = "xion1user",
 ) {
+  // Build a minimal mock runtime that mirrors the new dispatch logic in
+  // `runtime.manageAuthenticators` / `runtime.isManageAuthSupported`.
+  const isSupported =
+    controller instanceof PopupController ||
+    controller instanceof IframeController ||
+    controller instanceof RedirectController;
+  const runtime = {
+    isManageAuthSupported: isSupported,
+    manageAuthUnsupportedReason: isSupported
+      ? undefined
+      : "Manage authenticators is not supported in signer mode. Use popup, redirect, or embedded authentication to add or remove authenticators.",
+    manageAuthenticators: vi.fn(async (addr: string) => {
+      if (controller instanceof PopupController) {
+        return controller.promptManageAuthenticators(addr);
+      }
+      if (controller instanceof IframeController) {
+        return controller.promptManageAuthenticators(addr);
+      }
+      if (controller instanceof RedirectController) {
+        return controller.promptManageAuthenticators(addr);
+      }
+      throw new Error(
+        "manageAuthenticators is not supported in the current authentication mode.",
+      );
+    }),
+  };
   return {
     controller,
+    runtime,
     granterAddress,
     // Other required context fields (unused by this hook)
     isConnected: !!granterAddress,

--- a/packages/abstraxion-react/src/hooks/useAbstraxionClient.ts
+++ b/packages/abstraxion-react/src/hooks/useAbstraxionClient.ts
@@ -1,12 +1,15 @@
 import { useContext, useEffect, useState } from "react";
-import { CosmWasmClient, testnetChainInfo } from "@burnt-labs/abstraxion-js";
+import {
+  CosmWasmClient,
+  testnetChainInfo,
+} from "@burnt-labs/abstraxion-js";
 import { AbstraxionContext } from "@/src/AbstraxionProvider";
 
 export const useAbstraxionClient = (): {
   readonly client: CosmWasmClient | undefined;
   readonly error: Error | undefined;
 } => {
-  const { rpcUrl } = useContext(AbstraxionContext);
+  const { rpcUrl, runtime } = useContext(AbstraxionContext);
 
   const [abstractClient, setAbstractClient] = useState<
     CosmWasmClient | undefined
@@ -14,16 +17,16 @@ export const useAbstraxionClient = (): {
   const [error, setError] = useState<Error | undefined>(undefined);
 
   useEffect(() => {
+    let cancelled = false;
     async function getClient() {
       try {
         setError(undefined);
-        const client = await CosmWasmClient.connect(
-          // Should be set in the context but defaulting here just in case
-          rpcUrl || testnetChainInfo.rpc,
-        );
-
-        setAbstractClient(client);
+        const client = runtime
+          ? await runtime.createReadClient()
+          : await CosmWasmClient.connect(rpcUrl || testnetChainInfo.rpc);
+        if (!cancelled) setAbstractClient(client);
       } catch (err) {
+        if (cancelled) return;
         const errorMessage = err instanceof Error ? err.message : String(err);
         setError(
           new Error(
@@ -35,7 +38,10 @@ export const useAbstraxionClient = (): {
     }
 
     getClient();
-  }, [rpcUrl]);
+    return () => {
+      cancelled = true;
+    };
+  }, [rpcUrl, runtime]);
 
   return {
     client: abstractClient,

--- a/packages/abstraxion-react/src/hooks/useAbstraxionClient.ts
+++ b/packages/abstraxion-react/src/hooks/useAbstraxionClient.ts
@@ -1,8 +1,5 @@
 import { useContext, useEffect, useState } from "react";
-import {
-  CosmWasmClient,
-  testnetChainInfo,
-} from "@burnt-labs/abstraxion-js";
+import { CosmWasmClient, testnetChainInfo } from "@burnt-labs/abstraxion-js";
 import { AbstraxionContext } from "@/src/AbstraxionProvider";
 
 export const useAbstraxionClient = (): {

--- a/packages/abstraxion-react/src/hooks/useAbstraxionSigningClient.ts
+++ b/packages/abstraxion-react/src/hooks/useAbstraxionSigningClient.ts
@@ -1,25 +1,12 @@
 import {
   useContext,
-  useMemo,
   useState,
   useEffect,
   useCallback,
   useSyncExternalStore,
 } from "react";
-import {
-  AAClient,
-  createSignerFromSigningFunction,
-  GasPrice,
-  IframeController,
-  PopupController,
-  RedirectController,
-  RequireSigningClient,
-} from "@burnt-labs/abstraxion-js";
-import type {
-  AuthenticatorType,
-  SigningClient,
-  SignResult,
-} from "@burnt-labs/abstraxion-js";
+import { RedirectController } from "@burnt-labs/abstraxion-js";
+import type { SigningClient, SignResult } from "@burnt-labs/abstraxion-js";
 import { AbstraxionContext } from "@/src/AbstraxionProvider";
 
 /**
@@ -48,66 +35,29 @@ export interface UseAbstraxionSigningClientOptions {
 
 /**
  * Return type for useAbstraxionSigningClient hook
- * Client type depends on requireAuth option
  */
 export interface UseAbstraxionSigningClientReturn {
-  /**
-   * Signing client — the concrete type depends on auth mode and `requireAuth`.
-   * Use the exported `SigningClient` type for your own type annotations.
-   */
   readonly client: SigningClient | undefined;
-
-  /**
-   * Sign arbitrary message function (from session keypair)
-   * Only available for session key signing
-   */
   readonly signArb:
     | ((signerAddress: string, message: string | Uint8Array) => Promise<string>)
     | undefined;
-
-  /**
-   * RPC URL for the chain
-   */
   readonly rpcUrl: string;
-
-  /**
-   * Error message if direct signing is not available
-   * Only set when requireAuth is true and connection info is missing
-   */
   readonly error: string | undefined;
-
   /**
    * Result from a redirect signing flow (populated after returning from the
    * dashboard signing redirect). null when no result is pending.
-   * Only relevant for redirect mode with requireAuth: true.
    */
   readonly signResult: SignResult | null;
-
-  /**
-   * Clear the signResult after consuming it.
-   * Only available when signResult is non-null.
-   */
+  /** Clear the signResult after consuming it. */
   readonly clearSignResult: (() => void) | undefined;
 }
 
 /**
- * Hook to get a signing client for transactions
+ * Hook to get a signing client for transactions.
  *
- * @param options - Hook options
- * @param options.requireAuth - When true, returns a direct signing client
- * @returns Signing client and related utilities
- *
- * @example
- * ```typescript
- * // Session key signing (default - gasless, no popup)
- * const { client } = useAbstraxionSigningClient();
- *
- * // Direct signing (wallet popup or dashboard approval, user pays gas)
- * const { client, error } = useAbstraxionSigningClient({ requireAuth: true });
- * if (error) {
- *   // Handle error - e.g., show message that direct signing is not available
- * }
- * ```
+ * Internally delegates direct-signing client construction to
+ * `runtime.createDirectSigningClient()`, which covers all four modes
+ * (popup / redirect / embedded / signer) with a single async call.
  */
 export const useAbstraxionSigningClient = (
   options?: UseAbstraxionSigningClientOptions,
@@ -115,169 +65,64 @@ export const useAbstraxionSigningClient = (
   const {
     abstraxionAccount,
     rpcUrl,
-    gasPrice,
     granterAddress,
     signingClient: signingClientFromState,
-    connectionInfo,
     authMode,
     controller,
+    runtime,
   } = useContext(AbstraxionContext);
 
   const requireAuth = options?.requireAuth ?? false;
 
-  // Narrow controller to mode-specific types
-  const popupController =
-    controller instanceof PopupController ? controller : undefined;
-  const redirectController =
-    controller instanceof RedirectController ? controller : undefined;
-  const iframeController =
-    controller instanceof IframeController ? controller : undefined;
-
-  // State for AAClient (created async, signer mode only)
-  const [aaClient, setAaClient] = useState<AAClient | undefined>(undefined);
+  const [directClient, setDirectClient] = useState<SigningClient | undefined>(
+    undefined,
+  );
   const [error, setError] = useState<string | undefined>(undefined);
 
-  // RequireSigningClient for popup / redirect / iframe modes (synchronous).
-  // The transport strategy is bound from the active controller method.
-  const requireSigningClient = useMemo(() => {
-    if (!requireAuth || !granterAddress) return undefined;
-
-    if (popupController) {
-      return new RequireSigningClient(
-        popupController.promptSignAndBroadcast.bind(popupController),
-        rpcUrl,
-      );
-    }
-    if (redirectController) {
-      return new RequireSigningClient(
-        redirectController.promptSignAndBroadcast.bind(redirectController),
-        rpcUrl,
-      );
-    }
-    if (iframeController) {
-      return new RequireSigningClient(
-        iframeController.signAndBroadcastWithMetaAccount.bind(iframeController),
-        rpcUrl,
-      );
-    }
-    return undefined;
-  }, [
-    requireAuth,
-    granterAddress,
-    popupController,
-    redirectController,
-    iframeController,
-    rpcUrl,
-  ]);
-
-  // Read sign result from RedirectController via useSyncExternalStore so the
-  // hook re-renders whenever signResult changes (set during init, cleared by consumer).
+  // RedirectController exposes a signResult store that survives the
+  // navigation round-trip. Subscribe via useSyncExternalStore so consumers
+  // can read it after returning from the dashboard.
+  const redirectController =
+    controller instanceof RedirectController ? controller : undefined;
   const signResult = useSyncExternalStore(
     (cb) => redirectController?.signResult.subscribe(cb) ?? (() => {}),
     () => redirectController?.signResult.snapshot() ?? null,
     () => null,
   );
-
   const clearSignResult = useCallback(() => {
     redirectController?.signResult.clear();
   }, [redirectController]);
 
-  // Create AAClient when requireAuth is true and in signer mode
   useEffect(() => {
-    // Reset state on mode change
-    if (!requireAuth) {
-      setAaClient(undefined);
+    if (!requireAuth || !runtime) {
+      setDirectClient(undefined);
       setError(undefined);
       return;
     }
 
-    // Popup / redirect / embedded: handled by RequireSigningClient (above).
-    // Only set an error if the relevant controller is missing.
-    if (authMode === "popup") {
-      setAaClient(undefined);
-      if (!popupController) {
-        setError(
-          "Direct signing requires an active connection. Please ensure you are logged in.",
-        );
-      } else {
-        setError(undefined);
-      }
-      return;
-    }
-
-    if (authMode === "redirect") {
-      setAaClient(undefined);
-      if (!redirectController) {
-        setError(
-          "Direct signing requires an active connection. Please ensure you are logged in.",
-        );
-      } else {
-        setError(undefined);
-      }
-      return;
-    }
-
-    if (authMode === "embedded") {
-      setAaClient(undefined);
-      if (!iframeController) {
-        setError(
-          "Direct signing requires an active connection. Please ensure you are logged in.",
-        );
-      } else {
-        setError(undefined);
-      }
-      return;
-    }
-
-    // Signer mode: create AAClient from connectionInfo
-    if (!connectionInfo) {
-      setError(
-        "Direct signing requires an active connection. Please ensure you are logged in.",
-      );
-      setAaClient(undefined);
-      return;
-    }
-
-    if (!granterAddress) {
+    // Signer mode: AAClient construction needs a connected account. Surface a
+    // friendly error if we're not there yet — the consumer typically waits
+    // for `granterAddress` before issuing a tx anyway.
+    if (authMode === "signer" && !granterAddress) {
+      setDirectClient(undefined);
       setError(
         "Direct signing requires a connected account. Please ensure you are logged in.",
       );
-      setAaClient(undefined);
       return;
     }
 
-    // Create AAClient
-    const createClient = async () => {
-      try {
-        const authenticatorType = connectionInfo.metadata
-          ?.authenticatorType as AuthenticatorType;
-        const authenticatorIndex =
-          connectionInfo.metadata?.authenticatorIndex ?? 0;
-
-        if (!authenticatorType) {
-          throw new Error(
-            "Authenticator type not available in connection info",
-          );
-        }
-
-        // Create signer from signing function
-        const signer = createSignerFromSigningFunction({
-          smartAccountAddress: granterAddress,
-          authenticatorIndex,
-          authenticatorType,
-          signMessage: connectionInfo.signMessage,
-        });
-
-        // Create AAClient
-        const client = await AAClient.connectWithSigner(rpcUrl, signer, {
-          gasPrice: GasPrice.fromString(gasPrice),
-        });
-
-        setAaClient(client);
+    let cancelled = false;
+    runtime
+      .createDirectSigningClient()
+      .then((client) => {
+        if (cancelled) return;
+        setDirectClient(client);
         setError(undefined);
-      } catch (err) {
+      })
+      .catch((err) => {
+        if (cancelled) return;
         console.error(
-          "[useAbstraxionSigningClient] Error creating AAClient:",
+          "[useAbstraxionSigningClient] createDirectSigningClient failed:",
           err,
         );
         setError(
@@ -285,39 +130,18 @@ export const useAbstraxionSigningClient = (
             ? err.message
             : "Failed to create direct signing client",
         );
-        setAaClient(undefined);
-      }
+        setDirectClient(undefined);
+      });
+
+    return () => {
+      cancelled = true;
     };
+  }, [requireAuth, runtime, authMode, granterAddress]);
 
-    createClient();
-  }, [
-    requireAuth,
-    connectionInfo,
-    granterAddress,
-    rpcUrl,
-    gasPrice,
-    authMode,
-    controller,
-  ]);
-
-  // Return appropriate client based on mode
   if (requireAuth) {
-    // Popup / redirect / iframe: return RequireSigningClient (unified transport-strategy client)
-    if (authMode === "popup") {
-      return {
-        client: requireSigningClient,
-        signArb: undefined,
-        rpcUrl,
-        error,
-        signResult: null,
-        clearSignResult: undefined,
-      };
-    }
-
-    // Redirect mode: also expose signResult store for consuming the post-redirect result
     if (authMode === "redirect") {
       return {
-        client: requireSigningClient,
+        client: directClient,
         signArb: undefined,
         rpcUrl,
         error,
@@ -326,21 +150,8 @@ export const useAbstraxionSigningClient = (
       };
     }
 
-    // Embedded (iframe) mode
-    if (authMode === "embedded") {
-      return {
-        client: requireSigningClient,
-        signArb: undefined,
-        rpcUrl,
-        error,
-        signResult: null,
-        clearSignResult: undefined,
-      };
-    }
-
-    // Signer mode: return AAClient (has full direct-key access)
     return {
-      client: aaClient,
+      client: directClient,
       signArb: undefined,
       rpcUrl,
       error,
@@ -349,7 +160,6 @@ export const useAbstraxionSigningClient = (
     };
   }
 
-  // Default: session key signing
   return {
     client: signingClientFromState,
     signArb: abstraxionAccount?.signArb,

--- a/packages/abstraxion-react/src/hooks/useManageAuthenticators.ts
+++ b/packages/abstraxion-react/src/hooks/useManageAuthenticators.ts
@@ -4,65 +4,51 @@
  * Opens the dashboard so the user can add or remove authenticators on their
  * XION account. Supports popup, iframe (embedded), and redirect modes.
  *
+ * Delegates to `runtime.manageAuthenticators` / `runtime.isManageAuthSupported`
+ * so the same logic powers React, React Native, Svelte, and any other
+ * framework wrapper.
  */
 
 import { useCallback, useContext, useSyncExternalStore } from "react";
-import {
-  IframeController,
-  PopupController,
-  RedirectController,
-} from "@burnt-labs/abstraxion-js";
+import { RedirectController } from "@burnt-labs/abstraxion-js";
 import type { ManageAuthResult } from "@burnt-labs/abstraxion-js";
 import { AbstraxionContext } from "../AbstraxionProvider";
 
 export interface UseManageAuthenticatorsReturn {
-  /** Open the manage-authenticators flow. Resolves when done (popup/iframe) or navigates away (redirect). */
   manageAuthenticators: () => Promise<void>;
-  /** True when the current authentication mode supports manage-authenticators. */
   isSupported: boolean;
-  /**
-   * Populated for redirect mode only — contains the result after the user
-   * returns from the dashboard manage-authenticators page. Always null for
-   * popup and iframe modes.
-   */
+  /** Human-readable reason when `isSupported` is false; `undefined` otherwise. */
+  unsupportedReason: string | undefined;
   manageAuthResult: ManageAuthResult | null;
-  /** Clear `manageAuthResult` once handled. No-op in non-redirect modes. */
   clearManageAuthResult: () => void;
 }
 
 export function useManageAuthenticators(): UseManageAuthenticatorsReturn {
-  const { controller, granterAddress } = useContext(AbstraxionContext);
+  const { runtime, controller, granterAddress } = useContext(AbstraxionContext);
 
-  const isSupported =
-    controller instanceof PopupController ||
-    controller instanceof IframeController ||
-    controller instanceof RedirectController;
+  const isSupported = runtime?.isManageAuthSupported ?? false;
+  const unsupportedReason = isSupported
+    ? undefined
+    : (runtime?.manageAuthUnsupportedReason ??
+      "useManageAuthenticators: AbstraxionProvider is not mounted.");
 
   const manageAuthenticators = useCallback(async () => {
+    if (!runtime) {
+      throw new Error(
+        "useManageAuthenticators: AbstraxionProvider is not mounted.",
+      );
+    }
     if (!granterAddress) {
       throw new Error(
         "useManageAuthenticators: user is not connected. Call login() first.",
       );
     }
+    return runtime.manageAuthenticators(granterAddress);
+  }, [runtime, granterAddress]);
 
-    if (
-      controller instanceof PopupController ||
-      controller instanceof IframeController
-    ) {
-      return controller.promptManageAuthenticators(granterAddress);
-    }
-
-    if (controller instanceof RedirectController) {
-      return controller.promptManageAuthenticators(granterAddress);
-    }
-
-    throw new Error(
-      "useManageAuthenticators is not supported in the current authentication mode. " +
-        "Use popup, iframe (embedded), or redirect authentication.",
-    );
-  }, [controller, granterAddress]);
-
-  // For redirect mode: subscribe to manageAuthResult via useSyncExternalStore
+  // Redirect mode: the manage-auth result survives the navigation round-trip
+  // via the controller's manageAuthResult store. Subscribe via
+  // useSyncExternalStore so consumers see the result on return.
   const manageAuthResult = useSyncExternalStore(
     (cb) =>
       controller instanceof RedirectController
@@ -84,6 +70,7 @@ export function useManageAuthenticators(): UseManageAuthenticatorsReturn {
   return {
     manageAuthenticators,
     isSupported,
+    unsupportedReason,
     manageAuthResult,
     clearManageAuthResult,
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,7 +145,7 @@ importers:
         version: 6.0.3
       expo:
         specifier: ~54.0.0
-        version: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+        version: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       expo-linking:
         specifier: ~8.0.12
         version: 8.0.12(expo@54.0.34)(react-native@0.81.5)(react@19.1.0)
@@ -182,6 +182,9 @@ importers:
       react-native-web:
         specifier: ~0.21.0
         version: 0.21.2(react-dom@19.1.0)(react@19.1.0)
+      react-native-webview:
+        specifier: 13.13.5
+        version: 13.13.5(react-native@0.81.5)(react@19.1.0)
     devDependencies:
       '@types/react':
         specifier: ^18.2.47
@@ -484,6 +487,9 @@ importers:
       react-native-quick-crypto:
         specifier: ^0.7.0
         version: 0.7.17(react-native@0.81.5)(react@19.1.0)
+      react-native-webview:
+        specifier: '>=13.0.0'
+        version: 13.13.5(react-native@0.81.5)(react@19.1.0)
     devDependencies:
       '@testing-library/react':
         specifier: ^14.2.1
@@ -2975,7 +2981,7 @@ packages:
       connect: 3.7.0
       debug: 4.4.3(supports-color@10.2.2)
       env-editor: 0.4.2
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       expo-router: 6.0.23(@expo/metro-runtime@6.1.2)(@types/react@18.3.28)(expo-constants@18.0.13)(expo-linking@8.0.12)(expo@54.0.34)(react-dom@19.1.0)(react-native-safe-area-context@5.6.2)(react-native-screens@4.16.0)(react-native-web@0.21.2)(react-native@0.81.5)(react@19.1.0)
       expo-server: 1.0.6
       freeport-async: 2.0.0
@@ -3167,7 +3173,7 @@ packages:
       debug: 4.4.3(supports-color@10.2.2)
       dotenv: 16.4.7
       dotenv-expand: 11.0.7
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       getenv: 2.0.0
       glob: 13.0.6
       hermes-parser: 0.29.1
@@ -3194,7 +3200,7 @@ packages:
         optional: true
     dependencies:
       anser: 1.4.10
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       pretty-format: 29.7.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -3264,7 +3270,7 @@ packages:
       '@expo/json-file': 10.0.12
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3(supports-color@10.2.2)
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -6912,7 +6918,7 @@ packages:
       std-env: 3.10.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@20.19.37)(@vitest/ui@1.6.1)(jsdom@23.2.0)
+      vitest: 1.6.1(jsdom@23.2.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7835,7 +7841,7 @@ packages:
       babel-plugin-syntax-hermes-parser: 0.29.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
       debug: 4.4.3(supports-color@10.2.2)
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       react-refresh: 0.14.2
       resolve-from: 5.0.0
     transitivePeerDependencies:
@@ -9771,7 +9777,7 @@ packages:
       react-native: '*'
     dependencies:
       '@expo/image-utils': 0.8.13(typescript@5.9.3)
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.1.0)
@@ -9788,7 +9794,7 @@ packages:
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -9800,7 +9806,7 @@ packages:
       expo: '*'
       react-native: '*'
     dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.1.0)
     dev: false
 
@@ -9811,7 +9817,7 @@ packages:
       react: '*'
       react-native: '*'
     dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.1.0)
@@ -9823,7 +9829,7 @@ packages:
       expo: '*'
       react: '*'
     dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
     dev: false
 
@@ -9908,7 +9914,7 @@ packages:
       client-only: 0.0.1
       debug: 4.4.3(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5)
       expo-linking: 8.0.12(expo@54.0.34)(react-native@0.81.5)(react@19.1.0)
       expo-server: 1.0.6
@@ -9959,11 +9965,11 @@ packages:
       expo: '*'
       react-native: '*'
     dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.1.0)
     dev: false
 
-  /expo@54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3):
+  /expo@54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.13.5)(react-native@0.81.5)(react@19.1.0)(typescript@5.9.3):
     resolution: {integrity: sha512-XkVHguZZDC8BcTQxHAd14/TQFbDp1Wt0Z/KApO9t68Ll5A127hLCPzU+a9gytfCIiyL/V1IpF1vIcOLKEVAoNQ==}
     hasBin: true
     peerDependencies:
@@ -10002,6 +10008,7 @@ packages:
       pretty-format: 29.7.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.1.0)
+      react-native-webview: 13.13.5(react-native@0.81.5)(react@19.1.0)
       react-refresh: 0.14.2
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
@@ -14029,6 +14036,18 @@ packages:
       styleq: 0.1.3
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /react-native-webview@13.13.5(react-native@0.81.5)(react@19.1.0):
+    resolution: {integrity: sha512-MfC2B+woL4Hlj2WCzcb1USySKk+SteXnUKmKktOk/H/AQy5+LuVdkPKm8SknJ0/RxaxhZ48WBoTRGaqgR137hw==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+    dependencies:
+      escape-string-regexp: 4.0.0
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.1.0)
     dev: false
 
   /react-native@0.81.5(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.1.0):


### PR DESCRIPTION
## Summary

Restructure the `@burnt-labs/abstraxion` packages for v1.0.0. Creates a new
framework-agnostic core (`@burnt-labs/abstraxion-js`), slims the React
package, brings React Native to feature parity (including embedded WebView
mode), removes deprecated shared-config packages, and reorganizes demos
under `demos/`.

Spec: `.docs/tasks/abstraxion_package_restructure.md`

## What's in the box

**New package**
- `@burnt-labs/abstraxion-js` — framework-agnostic core. Owns the controllers
  (Iframe / Popup / Redirect / Signer), the `createAbstraxionRuntime`
  primitive, and the browser strategy implementations.

**Renamed / slimmed**
- `@burnt-labs/abstraxion` → `@burnt-labs/abstraxion-react`. Now a thin React
  wrapper built on `createAbstraxionRuntime`.

**React Native parity** (`@burnt-labs/abstraxion-react-native`)
- Provider rewritten on top of the runtime.
- `useAbstraxionAccount` / `useAbstraxionClient` /
  `useAbstraxionSigningClient` / `useManageAuthenticators` all delegate to
  the runtime — same shapes as the React hooks.
- New embedded mode: dashboard runs inside a `react-native-webview`
  `<WebView>` via the new `IframeTransportStrategy` abstraction, with bridge
  JS injected to preserve the existing dashboard `MessageChannel` protocol
  unchanged.
- `<AbstraxionEmbed>` component for RN with idle / connected / approval
  view options.
- `useAbstraxionSigningClient({ requireAuth: true })` now works for redirect
  and embedded modes (previously fenced off, despite the runtime supporting
  both).

**New `IframeTransportStrategy` abstraction**
- Lifted iframe transport out of `IframeController` into a strategy so the
  controller has no direct DOM dependency.
- `BrowserIframeTransportStrategy` (web) and `RNWebViewIframeTransport` (RN)
  both implement it.

**Demos reorganized**
- Old `apps/demo-app` removed; new demos live under `demos/react`,
  `demos/react-native`, `demos/svelte`, `demos/node`.
- React demo covers popup / redirect / embedded (inline + dynamic) /
  signer / manage-authenticators / direct signing.
- Svelte demo wires `createAbstraxionRuntime` into a Svelte store —
  proves the runtime is framework-agnostic.
- RN demo covers redirect + embedded modes.

**Shared config cleanup**
- Removed `packages/tailwind-config`, `packages/eslint-config-custom`,
  `packages/tsconfig`. Each package now extends a single root
  `xion.js/tsconfig.json` / `.eslintrc.js`.
- `@burnt-labs/ui` deprecated and removed from the active workspace
  (changeset added; not a supported v1 package).

**Additional fixes**

`<AbstraxionEmbed>` was collapsing the WebView to 0×0 throughout the entire
login round-trip when consumers didn't pass a `style` (the typical case for
`idleView="button"` / `"hidden"`), leaving any flow that needed in-dashboard
interaction unreachable.

- Auto-promote the WebView to a full-screen `<Modal>` during `isConnecting`
  (and existing approval flow), gated on `idleView !== "fullview"` and
  `approvalView === "modal"`. Visibility logic extracted to a pure
  `computeEmbedDisplayMode` helper.
- New `IframeController.cancelLogin()` — rejects in-flight `connect()`,
  unmounts the transport, resets state. `completeConnection()` now takes a
  `throwIfAborted` guard so a cancel mid-finalization can't dispatch
  `SET_CONNECTED` on a torn-down transport. Modal dismissal wires to it.
- Web embed audited and deliberately left alone — it falls through to
  `divProps.style` during connect and the demo + types already steer
  consumers to pass a `style`.
- Refreshed `abstraxion-react-native` README: corrected stale claims (embedded
  + manage-authenticators are now supported on RN; `auto`/`popup` throw at
  mount), fixed config signatures, added quick-start, demo link,
  visibility-state matrix, and exports overview.
- Tests: `cancelLogin()` covers sendRequest/waitForReady/completeConnection
  races; `AbstraxionEmbed.test.ts` covers the visibility matrix.