### PR TITLE
feat: simulate robustness helpers, daodao admin-null guard, revoke + …

### DIFF
--- a/.changeset/daodao-admin-null-guard.md
+++ b/.changeset/daodao-admin-null-guard.md
@@ -1,0 +1,5 @@
+---
+"@burnt-labs/account-management": patch
+---
+
+fix(account-management): reject the DaoDao indexer's unindexed-treasury placeholder. The indexer returns `{ admin: null, grantConfigs: {}, … }` (not a 404) for any contract it hasn't indexed; `DaoDaoTreasuryStrategy.validateAllResponse` now rejects when `admin` is null/absent instead of accepting it as a successful empty config. In a racing `CompositeTreasuryStrategy` this lets `DirectQueryTreasuryStrategy` win, so an un-indexed treasury no longer silently degrades the connect screen to "Read access only".

--- a/.changeset/derive-cosmos-bech32.md
+++ b/.changeset/derive-cosmos-bech32.md
@@ -1,0 +1,5 @@
+---
+"@burnt-labs/signers": minor
+---
+
+feat(signers): add `deriveCosmosBech32(rawPubkeyBase64, prefix)` pure helper in `crypto/` (exported from `@burnt-labs/signers/crypto` and the main entry). Derives a bech32 account address from a raw secp256k1 public key, returning `null` on invalid input. Lets dashboard/xion-app consumers stop hand-rolling pubkey→address derivation.

--- a/.changeset/get-msg-type-url-for-revoke.md
+++ b/.changeset/get-msg-type-url-for-revoke.md
@@ -1,0 +1,5 @@
+---
+"@burnt-labs/account-management": minor
+---
+
+feat(account-management): add `getMsgTypeUrlForRevoke(authorizationTypeUrl, stakeAuthType?)` pure helper in `grants/` (exported from `@burnt-labs/account-management`). Maps an authz authorization `@type` to the `MsgRevoke`-able msg type URL, including the `StakeAuthorization` delegate/undelegate/redelegate variants (keyed by enum name or numeric proto value). Lets dashboard/xion-app consumers drop their local copies.

--- a/.changeset/simulate-robustness-helpers.md
+++ b/.changeset/simulate-robustness-helpers.md
@@ -1,0 +1,5 @@
+---
+"@burnt-labs/abstraxion-core": minor
+---
+
+feat(abstraxion-core): add framework-agnostic simulate robustness helpers — `classifySimulateError` / `diagnoseSimulateError` / `classifyGrantError`, the `SIMULATE_RETRY_COUNT` / `SIMULATE_RETRY_DELAY_MS` / `SIMULATE_FALLBACK_GAS` constants, and a generic `simulateWithRetry` (classification + bounded retry + concrete-fee fallback) that composes with any cosmjs-shaped `{ simulate(...) }` client. The logger is injectable (defaults to `console.warn`) and the context label is a plain string, so non-dashboard callers (`RequireSigningClient`, `GranteeSignerClient`, `AAClient`, plain cosmjs) can reuse it without dashboard-specific coupling.

--- a/packages/abstraxion-core/src/index.ts
+++ b/packages/abstraxion-core/src/index.ts
@@ -23,3 +23,6 @@ export {
   fetchFromDaoDaoIndexer,
   type TreasuryIndexerConfig,
 } from "./utils/indexer/treasury-indexer";
+
+// Simulate robustness: classification + bounded retry + concrete-fee fallback
+export * from "./utils/simulate";

--- a/packages/abstraxion-core/src/utils/index.ts
+++ b/packages/abstraxion-core/src/utils/index.ts
@@ -37,4 +37,7 @@ export function makeADR36AminoSignDoc(
 export { customAccountFromAny } from "@burnt-labs/signers";
 export { getRpcClient } from "./rpcClient";
 export { fetchConfig, clearConfigCache } from "./configUtils";
-export * from "./simulate";
+// NOTE: simulate helpers are intentionally NOT re-exported here. `./simulate`
+// imports `wait` from this barrel, so re-exporting it back would form an
+// import cycle that is brittle across bundlers/TS emit targets. The package
+// root (`src/index.ts`) already exposes them via `export * from "./utils/simulate"`.

--- a/packages/abstraxion-core/src/utils/index.ts
+++ b/packages/abstraxion-core/src/utils/index.ts
@@ -37,3 +37,4 @@ export function makeADR36AminoSignDoc(
 export { customAccountFromAny } from "@burnt-labs/signers";
 export { getRpcClient } from "./rpcClient";
 export { fetchConfig, clearConfigCache } from "./configUtils";
+export * from "./simulate";

--- a/packages/abstraxion-core/src/utils/simulate/__tests__/classify.test.ts
+++ b/packages/abstraxion-core/src/utils/simulate/__tests__/classify.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyGrantError,
+  classifySimulateError,
+  diagnoseSimulateError,
+} from "../classify";
+
+describe("classifySimulateError", () => {
+  it("classifies authz code 2 as non-blocking", () => {
+    expect(
+      classifySimulateError(
+        new Error(
+          "Broadcasting transaction failed with code 2 (codespace: authz): authorization not found",
+        ),
+      ),
+    ).toBe("non-blocking");
+  });
+
+  it("classifies generic Querier contract errors as non-blocking", () => {
+    expect(
+      classifySimulateError(
+        new Error("Querier contract error: smart account not initialised"),
+      ),
+    ).toBe("non-blocking");
+  });
+
+  it("classifies account sequence mismatch as transient", () => {
+    expect(
+      classifySimulateError(
+        new Error("account sequence mismatch, expected 5, got 4"),
+      ),
+    ).toBe("transient");
+  });
+
+  it("classifies socket timeout as transient", () => {
+    expect(classifySimulateError(new Error("request timed out"))).toBe(
+      "transient",
+    );
+    expect(classifySimulateError(new Error("ECONNRESET"))).toBe("transient");
+  });
+
+  it("classifies unknown messages as fatal", () => {
+    expect(
+      classifySimulateError(new Error("invalid grant config: missing field")),
+    ).toBe("fatal");
+    expect(classifySimulateError("something string-y")).toBe("fatal");
+    expect(classifySimulateError(undefined)).toBe("fatal");
+  });
+
+  // Simulate-time wire-format / contract-version mismatch is `non-blocking`
+  // — the signed broadcast that follows carries a real credential so
+  // contract-side guards are satisfied; only the simulate placeholder trips
+  // the older AA contract version.
+  it("classifies 'signature is empty' as non-blocking — the signed broadcast lands fine", () => {
+    const err = new Error(
+      "Query failed with (6): rpc error: code = Unknown desc = signature is empty: execute wasm contract failed with gas used: '44192': unknown request",
+    );
+    expect(classifySimulateError(err)).toBe("non-blocking");
+    expect(diagnoseSimulateError(err)).toMatch(/alpha\.9/);
+  });
+
+  it("classifies 'EmptySignature' contract error as non-blocking with a diagnosis hint", () => {
+    const err = new Error(
+      "dispatch: EmptySignature: execute wasm contract failed",
+    );
+    expect(classifySimulateError(err)).toBe("non-blocking");
+    expect(diagnoseSimulateError(err)).toMatch(
+      /wire-format mismatch|postmortem/i,
+    );
+  });
+
+  it("returns null diagnosis for non-protocol-mismatch errors", () => {
+    expect(
+      diagnoseSimulateError(new Error("account sequence mismatch")),
+    ).toBeNull();
+    expect(
+      diagnoseSimulateError(new Error("codespace: authz, code: 2")),
+    ).toBeNull();
+    expect(diagnoseSimulateError(new Error("anything else"))).toBeNull();
+  });
+});
+
+describe("classifyGrantError", () => {
+  it("classifies missing-authenticator errors as account", () => {
+    expect(
+      classifyGrantError(
+        new Error("Authenticator at index 0 not found for account xion1…"),
+      ),
+    ).toBe("account");
+  });
+
+  it("classifies invalid contract grant errors as config", () => {
+    expect(
+      classifyGrantError(new Error("InvalidContractGrant: bad limit shape")),
+    ).toBe("config");
+  });
+
+  it("classifies unsafe redirect URL as config", () => {
+    expect(classifyGrantError(new Error("Unsafe redirect URL detected"))).toBe(
+      "config",
+    );
+  });
+
+  it("classifies sequence mismatch as transient", () => {
+    expect(
+      classifyGrantError(
+        new Error("account sequence mismatch, expected 5, got 4"),
+      ),
+    ).toBe("transient");
+  });
+
+  it("classifies timeouts as transient", () => {
+    expect(classifyGrantError(new Error("request timed out"))).toBe(
+      "transient",
+    );
+  });
+
+  it("falls back to unknown for unrecognised errors", () => {
+    expect(classifyGrantError(new Error("kaboom"))).toBe("unknown");
+  });
+
+  it("accepts non-Error throwables via String()", () => {
+    expect(classifyGrantError("Authenticator not found")).toBe("account");
+    expect(classifyGrantError({ foo: "bar" })).toBe("unknown");
+  });
+});
+
+// ── Pattern-affirmation tables ──────────────────────────────────────
+// One representative message per regex alternation, so a future edit that
+// breaks a single pattern is caught individually. (Branch *outcomes* are
+// covered by the cases above; these guard each alternation as a regression
+// fence and document what real chain errors each pattern is meant to catch.)
+
+describe("classifySimulateError — transient alternations", () => {
+  it.each([
+    ["account sequence mismatch, expected 5, got 4"],
+    ["incorrect account sequence"],
+    ["request timed out"],
+    ["connection timeout"],
+    ["ECONNRESET"],
+    ["ENETUNREACH"],
+    ["ETIMEDOUT"],
+    ["rpc error: service temporarily unavailable"],
+  ])("classifies %j as transient", (msg) => {
+    expect(classifySimulateError(new Error(msg))).toBe("transient");
+  });
+});
+
+describe("classifySimulateError — non-blocking alternations", () => {
+  it.each([
+    // authz code 2, codespace-first ordering
+    ["failed to execute; codespace: authz, code: 2: authorization not found"],
+    // authz code 2, code-first ordering
+    ["broadcast failed with code: 2 — codespace: authz"],
+    ["Querier contract error: account not initialised"],
+    // protocol-mismatch signals (also non-blocking)
+    ["rpc error: signature is empty: execute wasm contract failed"],
+    ["dispatch: EmptySignature: execute wasm contract failed"],
+  ])("classifies %j as non-blocking", (msg) => {
+    expect(classifySimulateError(new Error(msg))).toBe("non-blocking");
+  });
+
+  it("does not match code 20 as authz code 2 (word-boundary guard)", () => {
+    expect(
+      classifySimulateError(
+        new Error("codespace: authz, code: 20: out of gas"),
+      ),
+    ).toBe("fatal");
+  });
+});
+
+describe("diagnoseSimulateError — non-Error inputs", () => {
+  it("extracts the message from a non-Error throwable that still matches", () => {
+    // Exercises the String(error) branch on a non-Error value.
+    expect(diagnoseSimulateError("signature is empty")).toMatch(/alpha\.9/);
+  });
+
+  it("returns null for a non-Error with no protocol match", () => {
+    expect(diagnoseSimulateError({ some: "object" })).toBeNull();
+  });
+});
+
+describe("classifyGrantError — account alternations", () => {
+  it.each([
+    ["Authenticator at index 0 not found for account xion1…"],
+    ["authenticator NOT FOUND"],
+  ])("classifies %j as account", (msg) => {
+    expect(classifyGrantError(new Error(msg))).toBe("account");
+  });
+});
+
+describe("classifyGrantError — config alternations", () => {
+  it.each([
+    ["invalid contract grant: bad shape"],
+    ["invalid contract grants for treasury"],
+    ["InvalidContractGrant: limit"],
+    ["FeeGrantValidationError: insufficient allowance"],
+    ["contract not found"],
+    ["contract: not found"],
+    ["no such contract: xion1…"],
+    ["Unsafe redirect URL detected"],
+  ])("classifies %j as config", (msg) => {
+    expect(classifyGrantError(new Error(msg))).toBe("config");
+  });
+});
+
+describe("classifyGrantError — transient alternations (via simulate classifier)", () => {
+  it.each([
+    ["account sequence mismatch"],
+    ["incorrect account sequence"],
+    ["request timed out"],
+    ["ECONNRESET"],
+  ])("classifies %j as transient", (msg) => {
+    expect(classifyGrantError(new Error(msg))).toBe("transient");
+  });
+});

--- a/packages/abstraxion-core/src/utils/simulate/__tests__/retry.test.ts
+++ b/packages/abstraxion-core/src/utils/simulate/__tests__/retry.test.ts
@@ -252,10 +252,16 @@ describe("simulateWithRetry", () => {
     const simulate = vi.fn().mockRejectedValue("codespace: authz, code: 2");
     const client = { simulate };
 
-    const result = await simulateWithRetry(client, "xion1granter", msgs, "memo", {
-      ...context,
-      logger,
-    });
+    const result = await simulateWithRetry(
+      client,
+      "xion1granter",
+      msgs,
+      "memo",
+      {
+        ...context,
+        logger,
+      },
+    );
 
     expect(result.kind).toBe("fallback");
     const [, logPayload] = logger.mock.calls[0];

--- a/packages/abstraxion-core/src/utils/simulate/__tests__/retry.test.ts
+++ b/packages/abstraxion-core/src/utils/simulate/__tests__/retry.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  simulateWithRetry,
+  SIMULATE_RETRY_COUNT,
+  type SimulateContext,
+} from "../index";
+
+describe("simulateWithRetry", () => {
+  const context: SimulateContext = {
+    label: "treasury",
+    granter: "xion1granter",
+    grantee: "xion1grantee",
+    treasury: "xion1treasury",
+  };
+  const msgs = [{ typeUrl: "/cosmos.authz.v1beta1.MsgGrant" }];
+
+  it("returns success on first attempt when simulate resolves", async () => {
+    const simulate = vi.fn().mockResolvedValue(123_456);
+    const client = { simulate };
+
+    const result = await simulateWithRetry(
+      client,
+      "xion1granter",
+      msgs,
+      "memo",
+      context,
+    );
+
+    expect(result).toEqual({ kind: "success", simmedGas: 123_456 });
+    expect(simulate).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows on fatal errors without retrying", async () => {
+    const simulate = vi
+      .fn()
+      .mockRejectedValue(new Error("invalid grant config"));
+    const client = { simulate };
+
+    await expect(
+      simulateWithRetry(client, "xion1granter", msgs, "memo", context),
+    ).rejects.toThrow(/invalid grant config/);
+    expect(simulate).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back without retry on protocol-mismatch — broadcast will land", async () => {
+    const empty = new Error(
+      "rpc error: code = Unknown desc = signature is empty: execute wasm contract failed",
+    );
+    const simulate = vi.fn().mockRejectedValue(empty);
+    const client = { simulate };
+
+    const result = await simulateWithRetry(
+      client,
+      "xion1granter",
+      msgs,
+      "memo",
+      context,
+    );
+    expect(result.kind).toBe("fallback");
+    if (result.kind === "fallback") expect(result.lastError).toBe(empty);
+    // Exactly one simulate attempt — no retry, since a retry would hit
+    // the same wire-format incompatibility.
+    expect(simulate).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back on non-blocking errors without retrying", async () => {
+    const authzErr = new Error("codespace: authz, code: 2");
+    const simulate = vi.fn().mockRejectedValue(authzErr);
+    const client = { simulate };
+
+    const result = await simulateWithRetry(
+      client,
+      "xion1granter",
+      msgs,
+      "memo",
+      context,
+    );
+
+    expect(result.kind).toBe("fallback");
+    if (result.kind === "fallback") {
+      expect(result.lastError).toBe(authzErr);
+    }
+    expect(simulate).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transient errors and succeeds on the retry", async () => {
+    vi.useFakeTimers();
+    try {
+      const simulate = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("account sequence mismatch"))
+        .mockResolvedValueOnce(999);
+      const client = { simulate };
+
+      const promise = simulateWithRetry(
+        client,
+        "xion1granter",
+        msgs,
+        "memo",
+        context,
+      );
+      // Fire the retry backoff timer (and flush the follow-up retry).
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toEqual({ kind: "success", simmedGas: 999 });
+      expect(simulate).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back when all transient retries exhaust", async () => {
+    vi.useFakeTimers();
+    try {
+      const simulate = vi
+        .fn()
+        .mockRejectedValue(new Error("account sequence mismatch"));
+      const client = { simulate };
+
+      const promise = simulateWithRetry(
+        client,
+        "xion1granter",
+        msgs,
+        "memo",
+        context,
+      );
+      // Fire all retry backoff timers until the attempts exhaust.
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.kind).toBe("fallback");
+      // Initial attempt + SIMULATE_RETRY_COUNT retries
+      expect(simulate).toHaveBeenCalledTimes(SIMULATE_RETRY_COUNT + 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("logs structured warnings on every failed attempt", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const simulate = vi
+        .fn()
+        .mockRejectedValue(new Error("codespace: authz, code: 2"));
+      const client = { simulate };
+
+      await simulateWithRetry(
+        client,
+        "xion1someoneelse", // mismatched sender → granterMatchesSender=false
+        msgs,
+        "memo",
+        { ...context, chainId: "xion-mainnet-1" },
+      );
+
+      expect(warn).toHaveBeenCalledOnce();
+      const [logLabel, logPayload] = warn.mock.calls[0];
+      expect(logLabel).toBe("[Grant/treasury] simulate failed");
+      expect(logPayload).toMatchObject({
+        classification: "non-blocking",
+        diagnosis: null,
+        chainId: "xion-mainnet-1",
+        granter: "xion1granter",
+        grantee: "xion1grantee",
+        treasury: "xion1treasury",
+        granterMatchesSender: false,
+        msgTypes: ["/cosmos.authz.v1beta1.MsgGrant"],
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("attaches the diagnosis hint to the log on protocol-mismatch errors", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const simulate = vi
+        .fn()
+        .mockRejectedValue(
+          new Error("signature is empty: execute wasm contract failed"),
+        );
+      const client = { simulate };
+
+      const result = await simulateWithRetry(
+        client,
+        "xion1granter",
+        msgs,
+        "memo",
+        { ...context, chainId: "xion-mainnet-1" },
+      );
+      expect(result.kind).toBe("fallback");
+
+      const [, logPayload] = warn.mock.calls[0];
+      expect(logPayload).toMatchObject({
+        classification: "non-blocking",
+        chainId: "xion-mainnet-1",
+      });
+      expect((logPayload as { diagnosis: string }).diagnosis).toMatch(
+        /alpha\.9|FEFA4D0C/,
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("routes telemetry through an injected logger instead of console.warn", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const logger = vi.fn();
+      const simulate = vi
+        .fn()
+        .mockRejectedValue(new Error("codespace: authz, code: 2"));
+      const client = { simulate };
+
+      await simulateWithRetry(client, "xion1granter", msgs, "memo", {
+        ...context,
+        logger,
+      });
+
+      expect(logger).toHaveBeenCalledOnce();
+      const [logLabel, logPayload] = logger.mock.calls[0];
+      expect(logLabel).toBe("[Grant/treasury] simulate failed");
+      expect(logPayload).toMatchObject({ classification: "non-blocking" });
+      // Injected logger replaces console.warn entirely.
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("accepts an arbitrary string label (not just a grant-flow union)", async () => {
+    const logger = vi.fn();
+    const simulate = vi
+      .fn()
+      .mockRejectedValue(new Error("codespace: authz, code: 2"));
+    const client = { simulate };
+
+    await simulateWithRetry(client, "xion1granter", msgs, "memo", {
+      ...context,
+      label: "sign",
+      logger,
+    });
+
+    expect(logger.mock.calls[0][0]).toBe("[Grant/sign] simulate failed");
+  });
+
+  it("logs the String(error) form when simulate rejects with a non-Error", async () => {
+    const logger = vi.fn();
+    // Reject with a plain string (not an Error) — exercises the
+    // `error instanceof Error ? error.message : String(error)` non-Error
+    // branch in the log payload. Still classified from its string form.
+    const simulate = vi.fn().mockRejectedValue("codespace: authz, code: 2");
+    const client = { simulate };
+
+    const result = await simulateWithRetry(client, "xion1granter", msgs, "memo", {
+      ...context,
+      logger,
+    });
+
+    expect(result.kind).toBe("fallback");
+    const [, logPayload] = logger.mock.calls[0];
+    expect(logPayload).toMatchObject({
+      classification: "non-blocking",
+      message: "codespace: authz, code: 2",
+    });
+  });
+});

--- a/packages/abstraxion-core/src/utils/simulate/classify.ts
+++ b/packages/abstraxion-core/src/utils/simulate/classify.ts
@@ -1,0 +1,233 @@
+/**
+ * Simulate-error classification for grant / signing transactions.
+ *
+ * Clients run `client.simulate(...)` before broadcast to pre-compute gas.
+ * Some simulate failures are real (bad msg shape) and some are false
+ * positives (simulate disagrees with deliver — e.g. authz code 2 on a smart
+ * account that just hasn't been warmed up).
+ *
+ * We classify each failure into three buckets so the caller can decide
+ * whether to fail hard, retry, or fall back to broadcasting with a concrete
+ * `StdFee` (derived from `SIMULATE_FALLBACK_GAS`) and let the chain be the
+ * source of truth. The fallback fee is deliberately concrete and NOT
+ * `"auto"`: cosmjs's `"auto"` re-runs simulate internally, so it would just
+ * re-trip the same failure we're trying to route around.
+ *
+ * This module is framework-agnostic and client-agnostic: the classifiers
+ * are pure functions over an error value, and `simulateWithRetry` is generic
+ * over any structural `{ simulate(...) }` client. User-facing copy and any
+ * debug toggles stay in the consuming application, not here.
+ */
+
+/**
+ * Classification of a `client.simulate(...)` failure.
+ *
+ * - `fatal`: hard config/structure error. Surface to user, don't retry,
+ *   don't broadcast — the underlying tx would also fail.
+ * - `transient`: chain busy, sequence mismatch, AA warm-up. Retry simulate.
+ * - `non-blocking`: simulate disagrees with deliver but the *signed*
+ *   broadcast carries real credentials and would land. Skip retry,
+ *   broadcast with a concrete fallback fee (NOT `"auto"` — cosmjs's
+ *   `"auto"` re-runs simulate internally and would just re-fail).
+ */
+export type SimulateErrorClass = "fatal" | "transient" | "non-blocking";
+
+/**
+ * Retry policy for `transient` failures: how many attempts and the delay
+ * between them in milliseconds. The first attempt is always made; the
+ * retry count is the number of *additional* attempts.
+ */
+export const SIMULATE_RETRY_COUNT = 1;
+export const SIMULATE_RETRY_DELAY_MS = 1000;
+
+/**
+ * Default gas amount used to construct a concrete `StdFee` when simulate
+ * fails non-fatally. Derived from the dashboard's worst case: an 8-msg legacy
+ * grant + fee grant bundle at ≈ 130k gas (per the postmortem); treasury
+ * bundles are smaller. 400k gives ~3× headroom on that worst case before a
+ * gas-adjustment multiplier is applied — plenty of margin without paying for
+ * gas we'll never use. Fee-granted broadcasts pay nothing for unused gas;
+ * unfunded broadcasts pay sub-millicent worst case at this size.
+ *
+ * This is a sensible **default, not a law** — callers with a different worst
+ * case should override it with their own concrete gas figure.
+ */
+export const SIMULATE_FALLBACK_GAS = 400_000;
+
+const TRANSIENT_PATTERNS: RegExp[] = [
+  /account sequence mismatch/i,
+  /incorrect account sequence/i,
+  /timed?\s*out/i,
+  /econnreset|enetunreach|etimedout/i,
+  /rpc error.*temporarily/i,
+];
+
+/**
+ * Patterns that simulate fails on but a signed broadcast lands fine. These
+ * are wire-format / contract-version mismatches that only bite the
+ * placeholder-signature simulate path: the actual signAndBroadcast carries
+ * real credentials, so the contract's `cred_bytes` guard is satisfied.
+ *
+ * Treated as `non-blocking` (skip retry, broadcast directly), and tagged
+ * with a `hint` for telemetry so the next incident in this family is
+ * diagnosable from the console alone.
+ *
+ * The canonical case: `@burnt-labs/signers` pre-alpha.9 sent
+ * `signatures: [new Uint8Array()]`, which mainnet's pre-audit AA contract
+ * (`code_id 5`, `FEFA4D0C`) rejects with `EmptySignature` before the
+ * `simulate=true` skip. Broadcast is never affected because the signer fills
+ * `signatures[0]` with the real credential before sending — the pre-flight
+ * simulate is the only thing tripping the guard.
+ */
+interface ProtocolMismatchSignal {
+  pattern: RegExp;
+  hint: string;
+}
+
+const PROTOCOL_MISMATCH_SIGNALS: ProtocolMismatchSignal[] = [
+  {
+    pattern: /signature is empty/i,
+    hint: "AA simulate produced 'signature is empty' — typically @burnt-labs/signers < alpha.9 against a pre-audit-fix AA contract (e.g. mainnet code_id 5, FEFA4D0C). The signed broadcast still carries a real credential and will land; the simulate placeholder is the only thing tripping the guard. Verify SDK version and the granter's AA code_id.",
+  },
+  {
+    pattern: /EmptySignature/,
+    hint: "AA contract returned EmptySignature — simulate-only wire-format mismatch with the deployed contract version. Broadcast lands.",
+  },
+];
+
+const NON_BLOCKING_PATTERNS: RegExp[] = [
+  // authz code 2: simulate-time grant lookup race, observed on first-connect
+  // smart accounts that haven't warmed up yet. Deliver path consistently
+  // lands. The codespace/code pair can appear in either order depending on
+  // whether the error comes from a Tendermint broadcast response or a
+  // cosmjs-formatted simulate failure.
+  /codespace:\s*authz[\s\S]*code:?\s*2\b/i,
+  /code:?\s*2\b[\s\S]*codespace:\s*authz/i,
+  // Generic Querier error on a smart account that has no prior tx history —
+  // before_tx / after_tx hooks not yet primed. Deliver path lands.
+  /Querier contract error/i,
+];
+
+/**
+ * Classify a simulate error into one of `SimulateErrorClass`.
+ *
+ * Pattern matching is intentionally permissive: we'd rather risk one extra
+ * broadcast attempt than show the user a dead-end error. Anything we don't
+ * recognise is treated as `fatal` so the user sees a real message instead
+ * of a silently swallowed problem.
+ *
+ * Protocol-mismatch signals classify as `non-blocking` — they're
+ * simulate-only failures (placeholder-signature wire issues) and the
+ * signed broadcast that follows would land. They're broken out separately
+ * only so `diagnoseSimulateError` can attach a developer-targeted hint.
+ */
+export function classifySimulateError(error: unknown): SimulateErrorClass {
+  const message = error instanceof Error ? error.message : String(error);
+
+  for (const { pattern } of PROTOCOL_MISMATCH_SIGNALS) {
+    if (pattern.test(message)) return "non-blocking";
+  }
+
+  for (const pattern of NON_BLOCKING_PATTERNS) {
+    if (pattern.test(message)) return "non-blocking";
+  }
+
+  for (const pattern of TRANSIENT_PATTERNS) {
+    if (pattern.test(message)) return "transient";
+  }
+
+  return "fatal";
+}
+
+/**
+ * If the error matches a known protocol/version-mismatch signature, return
+ * a one-line diagnosis hint for the telemetry log. Returns null otherwise.
+ *
+ * The hint is intended for developers reading the console after an
+ * incident, not the end user — it names the SDK package, the contract
+ * version family, and points at the postmortem so the next investigator
+ * has a head start.
+ */
+export function diagnoseSimulateError(error: unknown): string | null {
+  const message = error instanceof Error ? error.message : String(error);
+  for (const { pattern, hint } of PROTOCOL_MISMATCH_SIGNALS) {
+    if (pattern.test(message)) return hint;
+  }
+  return null;
+}
+
+/**
+ * Classification for the outer grant-flow error caught after simulate +
+ * broadcast have already run. Different shape from `SimulateErrorClass`
+ * because "non-blocking" is a simulate-only concept — once we've reached the
+ * catch block in `grant()`, the broadcast has either failed for real or
+ * never happened.
+ *
+ * - `account`: the user's smart account isn't usable as-is for this grant —
+ *   canonically "Authenticator not found" on a first-connect account that
+ *   hasn't been instantiated. Retrying as-is won't help; the user resolves it
+ *   by disconnecting and logging in again, NOT by contacting the dApp team.
+ *   Broken out from `config` so the copy can give that actionable guidance.
+ * - `config`: dApp-side misconfiguration (bad contract grants, fee-grant
+ *   setup, treasury not deployed). The current operation will not succeed by
+ *   retrying as-is. Tell the user to contact the dApp team.
+ * - `transient`: chain busy, sequence mismatch, network blip. Retrying often
+ *   succeeds; surface a soft message and let the user hit Try again.
+ * - `unknown`: anything we don't recognise. Keep the generic copy but expose
+ *   the raw error behind a debug toggle so future incidents are diagnosable
+ *   without a code session.
+ */
+export type GrantErrorClass = "account" | "config" | "transient" | "unknown";
+
+/**
+ * Account-side errors the *user* can resolve by disconnecting + re-logging
+ * in. Checked before `CONFIG_ERROR_PATTERNS` so missing-authenticator gets
+ * its own actionable copy instead of the generic "contact the dApp" message.
+ */
+const ACCOUNT_ERROR_PATTERNS: RegExp[] = [
+  // First-connect smart accounts that haven't been instantiated yet.
+  /Authenticator[\s\S]*not found/i,
+];
+
+const CONFIG_ERROR_PATTERNS: RegExp[] = [
+  // Invalid contract grant config — consumers may surface a tailored message
+  // for these, but the catch in grant() may still see a thrown variant.
+  /invalid contract grants?/i,
+  /InvalidContractGrant/i,
+  // Fee-grant misconfiguration coming back from the API.
+  /FeeGrantValidationError/i,
+  // Treasury contract not deployed / address invalid.
+  /contract:?\s*not found/i,
+  /no such contract/i,
+  // URL safety guard from the abstraxion-config layer.
+  /Unsafe redirect URL/i,
+];
+
+/**
+ * Classify a grant-flow error into one of `GrantErrorClass`.
+ *
+ * Reuses `classifySimulateError`'s `transient` patterns when nothing else
+ * matches — chain-level transients look the same whether they came from
+ * simulate or broadcast. Anything we can't place falls through to `unknown`
+ * so the user still gets the dead-end UI's "show details" affordance instead
+ * of being lied to about the cause.
+ */
+export function classifyGrantError(error: unknown): GrantErrorClass {
+  const message = error instanceof Error ? error.message : String(error);
+
+  for (const pattern of ACCOUNT_ERROR_PATTERNS) {
+    if (pattern.test(message)) return "account";
+  }
+
+  for (const pattern of CONFIG_ERROR_PATTERNS) {
+    if (pattern.test(message)) return "config";
+  }
+
+  // Reuse the simulate classifier for chain-level transients — sequence
+  // mismatch / timeouts / RPC blips look identical on either path.
+  if (classifySimulateError(error) === "transient") {
+    return "transient";
+  }
+
+  return "unknown";
+}

--- a/packages/abstraxion-core/src/utils/simulate/index.ts
+++ b/packages/abstraxion-core/src/utils/simulate/index.ts
@@ -1,0 +1,2 @@
+export * from "./classify";
+export * from "./retry";

--- a/packages/abstraxion-core/src/utils/simulate/retry.ts
+++ b/packages/abstraxion-core/src/utils/simulate/retry.ts
@@ -96,7 +96,7 @@ export async function simulateWithRetry(
   client: SimulateLike,
   signer: string,
   messages: readonly { typeUrl: string }[],
-  memo: string,
+  memo: string | undefined,
   context: SimulateContext,
 ): Promise<SimulateRetryResult> {
   const totalAttempts = SIMULATE_RETRY_COUNT + 1;

--- a/packages/abstraxion-core/src/utils/simulate/retry.ts
+++ b/packages/abstraxion-core/src/utils/simulate/retry.ts
@@ -1,0 +1,145 @@
+/**
+ * Generic `simulate()` orchestration: classification + bounded retry +
+ * concrete-fee fallback, layered above any cosmjs-shaped client.
+ *
+ * Kept separate from the client classes on purpose: a cosmjs
+ * `SigningStargateClient.simulate()` returns `Promise<number>` and throws on
+ * failure, and that contract must not change. Robustness is layered here as
+ * free functions over a structural `SimulateLike`, so it composes with
+ * `RequireSigningClient`, `GranteeSignerClient`, `AAClient`, and plain
+ * cosmjs clients alike.
+ */
+
+import { wait } from "../index";
+import {
+  classifySimulateError,
+  diagnoseSimulateError,
+  SIMULATE_RETRY_COUNT,
+  SIMULATE_RETRY_DELAY_MS,
+} from "./classify";
+
+/**
+ * Structural shape `simulateWithRetry` requires of its client. Matches the
+ * cosmjs `simulate(signer, messages, memo): Promise<number>` signature, so
+ * any cosmjs-derived client (or a hand-rolled mock) satisfies it.
+ */
+export interface SimulateLike {
+  simulate(
+    signer: string,
+    messages: readonly { typeUrl: string }[],
+    memo?: string,
+  ): Promise<number>;
+}
+
+/**
+ * Structured logger for simulate-failure telemetry. Receives the log label
+ * and a structured payload — defaults to `console.warn` so existing callers
+ * keep their console telemetry, but non-dashboard callers can inject their
+ * own sink (or a no-op) instead of being forced into console output.
+ */
+export type SimulateLogger = (
+  message: string,
+  payload: Record<string, unknown>,
+) => void;
+
+/**
+ * Caller-supplied context that gets attached to every simulate-failure
+ * log line. Lets future incidents be diagnosed from log output alone — we
+ * record granter/grantee identity, the msg shapes that were simulated, the
+ * chain we're talking to, and whether the granter address matches the
+ * smart-account sender (mismatch is a noisy class of bug).
+ *
+ * `chainId` is optional but strongly recommended: the postmortem case
+ * (signers < alpha.9) only reproduced on mainnet, and an incident report
+ * that doesn't note the network costs hours to disambiguate.
+ */
+export interface SimulateContext {
+  granter: string;
+  grantee: string;
+  /** Treasury address when running the treasury grant path. */
+  treasury?: string;
+  /**
+   * Free-form label identifying the calling flow in logs (e.g. `"treasury"`,
+   * `"legacy"`, `"sign"`). Kept as a plain string so non-grant callers (the
+   * signing window) aren't forced into a grant-shaped union.
+   */
+  label: string;
+  /** Chain id the simulate is running against — mainnet vs testnet. */
+  chainId?: string;
+  /**
+   * Optional telemetry sink for failed attempts. Defaults to `console.warn`
+   * when omitted, preserving the existing console-logging behavior.
+   */
+  logger?: SimulateLogger;
+}
+
+export type SimulateRetryResult =
+  | { kind: "success"; simmedGas: number }
+  | { kind: "fallback"; lastError: unknown };
+
+/**
+ * Run `client.simulate(...)` with classification + bounded retry.
+ *
+ * - `fatal` errors re-throw immediately.
+ * - `transient` errors are retried `SIMULATE_RETRY_COUNT` times with a fixed
+ *   backoff before falling through to the `fallback` path.
+ * - `non-blocking` errors skip the retry and return a `fallback` result so
+ *   the caller can broadcast with a concrete fallback `StdFee` (derived from
+ *   `SIMULATE_FALLBACK_GAS`). NOT `fee: "auto"` — cosmjs re-simulates on
+ *   `"auto"` and would re-hit the same non-blocking failure.
+ *
+ * Every failed attempt logs a structured warning (via `context.logger`, or
+ * `console.warn` by default) so the caller doesn't need to wrap simulate
+ * themselves to keep telemetry.
+ */
+export async function simulateWithRetry(
+  client: SimulateLike,
+  signer: string,
+  messages: readonly { typeUrl: string }[],
+  memo: string,
+  context: SimulateContext,
+): Promise<SimulateRetryResult> {
+  const totalAttempts = SIMULATE_RETRY_COUNT + 1;
+  const log = context.logger ?? console.warn;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < totalAttempts; attempt++) {
+    try {
+      const simmedGas = await client.simulate(signer, messages, memo);
+      return { kind: "success", simmedGas };
+    } catch (error) {
+      lastError = error;
+      const classification = classifySimulateError(error);
+      const diagnosis = diagnoseSimulateError(error);
+
+      log(`[Grant/${context.label}] simulate failed`, {
+        attempt: attempt + 1,
+        classification,
+        diagnosis,
+        message: error instanceof Error ? error.message : String(error),
+        msgTypes: messages.map((m) => m.typeUrl),
+        chainId: context.chainId,
+        granter: context.granter,
+        grantee: context.grantee,
+        treasury: context.treasury,
+        granterMatchesSender: context.granter === signer,
+      });
+
+      if (classification === "fatal") {
+        throw error;
+      }
+
+      if (classification === "non-blocking") {
+        return { kind: "fallback", lastError: error };
+      }
+
+      // Transient — wait then retry, unless this was the last attempt.
+      if (attempt < totalAttempts - 1) {
+        await wait(SIMULATE_RETRY_DELAY_MS);
+        continue;
+      }
+    }
+  }
+
+  return { kind: "fallback", lastError };
+}

--- a/packages/account-management/src/grants/__tests__/revoke.test.ts
+++ b/packages/account-management/src/grants/__tests__/revoke.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  getMsgTypeUrlForRevoke,
+  STAKE_AUTHORIZATION_TYPE_URL,
+} from "../revoke";
+
+describe("getMsgTypeUrlForRevoke", () => {
+  describe("simple authorization → msg mappings", () => {
+    it.each([
+      [
+        "/cosmos.bank.v1beta1.SendAuthorization",
+        "/cosmos.bank.v1beta1.MsgSend",
+      ],
+      ["/cosmos.gov.v1beta1.VoteAuthorization", "/cosmos.gov.v1beta1.MsgVote"],
+      ["/cosmos.gov.v1.VoteAuthorization", "/cosmos.gov.v1.MsgVote"],
+      [
+        "/ibc.applications.transfer.v1.TransferAuthorization",
+        "/ibc.applications.transfer.v1.MsgTransfer",
+      ],
+      [
+        "/cosmwasm.wasm.v1.ContractExecutionAuthorization",
+        "/cosmwasm.wasm.v1.MsgExecuteContract",
+      ],
+      [
+        "/cosmwasm.wasm.v1.ContractMigrationAuthorization",
+        "/cosmwasm.wasm.v1.MsgMigrateContract",
+      ],
+      [
+        "/cosmos.distribution.v1beta1.SetWithdrawAddressAuthorization",
+        "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
+      ],
+    ])("maps %s → %s", (authType, expected) => {
+      expect(getMsgTypeUrlForRevoke(authType)).toBe(expected);
+    });
+  });
+
+  describe("StakeAuthorization variants", () => {
+    it.each([
+      ["AUTHORIZATION_TYPE_DELEGATE", "/cosmos.staking.v1beta1.MsgDelegate"],
+      [1, "/cosmos.staking.v1beta1.MsgDelegate"],
+      ["1", "/cosmos.staking.v1beta1.MsgDelegate"],
+      [
+        "AUTHORIZATION_TYPE_UNDELEGATE",
+        "/cosmos.staking.v1beta1.MsgUndelegate",
+      ],
+      [2, "/cosmos.staking.v1beta1.MsgUndelegate"],
+      ["2", "/cosmos.staking.v1beta1.MsgUndelegate"],
+      [
+        "AUTHORIZATION_TYPE_REDELEGATE",
+        "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+      ],
+      [3, "/cosmos.staking.v1beta1.MsgBeginRedelegate"],
+      ["3", "/cosmos.staking.v1beta1.MsgBeginRedelegate"],
+    ])(
+      "maps StakeAuthorization with type %s → %s",
+      (stakeAuthType, expected) => {
+        expect(
+          getMsgTypeUrlForRevoke(STAKE_AUTHORIZATION_TYPE_URL, stakeAuthType),
+        ).toBe(expected);
+      },
+    );
+
+    it("falls back to the authorization type url for an unknown stake type", () => {
+      expect(
+        getMsgTypeUrlForRevoke(
+          STAKE_AUTHORIZATION_TYPE_URL,
+          "AUTHORIZATION_TYPE_UNSPECIFIED",
+        ),
+      ).toBe(STAKE_AUTHORIZATION_TYPE_URL);
+    });
+
+    it("falls back when no stake type is provided", () => {
+      expect(getMsgTypeUrlForRevoke(STAKE_AUTHORIZATION_TYPE_URL)).toBe(
+        STAKE_AUTHORIZATION_TYPE_URL,
+      );
+    });
+  });
+
+  describe("unmapped authorizations", () => {
+    it("returns the input for GenericAuthorization (caller handles its msg field)", () => {
+      const generic = "/cosmos.authz.v1beta1.GenericAuthorization";
+      expect(getMsgTypeUrlForRevoke(generic)).toBe(generic);
+    });
+
+    it("returns the input for an unrecognized authorization type", () => {
+      expect(getMsgTypeUrlForRevoke("/some.unknown.Authorization")).toBe(
+        "/some.unknown.Authorization",
+      );
+    });
+
+    it("ignores stakeAuthType for non-stake authorizations", () => {
+      expect(
+        getMsgTypeUrlForRevoke("/cosmos.bank.v1beta1.SendAuthorization", 1),
+      ).toBe("/cosmos.bank.v1beta1.MsgSend");
+    });
+  });
+});

--- a/packages/account-management/src/grants/index.ts
+++ b/packages/account-management/src/grants/index.ts
@@ -15,6 +15,9 @@ export {
   generateStakeAndGovGrant,
 } from "./construction";
 
+// Revoke message-type mapping
+export { getMsgTypeUrlForRevoke, STAKE_AUTHORIZATION_TYPE_URL } from "./revoke";
+
 // Utility functions
 export * from "./utils";
 

--- a/packages/account-management/src/grants/revoke.ts
+++ b/packages/account-management/src/grants/revoke.ts
@@ -1,0 +1,82 @@
+/**
+ * Authorization → revoke message-type mapping
+ *
+ * Pure helpers for translating an authz authorization `@type` into the message
+ * type URL that a `MsgRevoke` must target in order to remove that grant.
+ */
+
+/** The authz `@type` for staking authorizations, handled specially below. */
+export const STAKE_AUTHORIZATION_TYPE_URL =
+  "/cosmos.staking.v1beta1.StakeAuthorization";
+
+/**
+ * Map of authorization `@type` → the msg type URL a `MsgRevoke` must target.
+ *
+ * Excludes `StakeAuthorization` (whose target depends on the authorization type)
+ * and `GenericAuthorization` (whose target is the authorization's own `msg`
+ * field, only known at runtime — callers handle that case before mapping).
+ */
+const REVOKE_MSG_TYPE_URL_BY_AUTHORIZATION: Record<string, string> = {
+  "/cosmos.bank.v1beta1.SendAuthorization": "/cosmos.bank.v1beta1.MsgSend",
+  "/cosmos.gov.v1beta1.VoteAuthorization": "/cosmos.gov.v1beta1.MsgVote",
+  "/cosmos.gov.v1.VoteAuthorization": "/cosmos.gov.v1.MsgVote",
+  "/ibc.applications.transfer.v1.TransferAuthorization":
+    "/ibc.applications.transfer.v1.MsgTransfer",
+  "/cosmwasm.wasm.v1.ContractExecutionAuthorization":
+    "/cosmwasm.wasm.v1.MsgExecuteContract",
+  "/cosmwasm.wasm.v1.ContractMigrationAuthorization":
+    "/cosmwasm.wasm.v1.MsgMigrateContract",
+  "/cosmos.distribution.v1beta1.SetWithdrawAddressAuthorization":
+    "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
+};
+
+/**
+ * Map of staking authorization type → the msg type URL a `MsgRevoke` must
+ * target. Keyed by both the enum name and its numeric proto value so either
+ * representation from the chain/API resolves correctly.
+ */
+const REVOKE_MSG_TYPE_URL_BY_STAKE_AUTH_TYPE: Record<string, string> = {
+  AUTHORIZATION_TYPE_DELEGATE: "/cosmos.staking.v1beta1.MsgDelegate",
+  "1": "/cosmos.staking.v1beta1.MsgDelegate",
+  AUTHORIZATION_TYPE_UNDELEGATE: "/cosmos.staking.v1beta1.MsgUndelegate",
+  "2": "/cosmos.staking.v1beta1.MsgUndelegate",
+  AUTHORIZATION_TYPE_REDELEGATE: "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+  "3": "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+};
+
+/**
+ * Resolve the message type URL a `MsgRevoke` must target to remove a grant of
+ * the given authorization type.
+ *
+ * `MsgRevoke` identifies a grant by its `msgTypeUrl`, which is *not* the
+ * authorization's own `@type` — e.g. revoking a `SendAuthorization` requires
+ * `msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend"`. This is a pure lookup over the
+ * known authz authorization types.
+ *
+ * For `StakeAuthorization`, the target depends on the authorization's
+ * `authorization_type`; pass it via `stakeAuthType` (accepts either the enum
+ * name, e.g. `"AUTHORIZATION_TYPE_DELEGATE"`, or its numeric proto value, e.g.
+ * `1` / `"1"`).
+ *
+ * For unrecognized inputs — including `GenericAuthorization`, whose revoke
+ * target is its own runtime `msg` field — the `authorizationTypeUrl` is
+ * returned unchanged so callers can decide how to handle it.
+ *
+ * @param authorizationTypeUrl - The authz authorization `@type`
+ * @param stakeAuthType - Staking authorization type (enum name or numeric value); only used for `StakeAuthorization`
+ * @returns The msg type URL to revoke, or `authorizationTypeUrl` if unmapped
+ */
+export function getMsgTypeUrlForRevoke(
+  authorizationTypeUrl: string,
+  stakeAuthType?: number | string,
+): string {
+  if (authorizationTypeUrl === STAKE_AUTHORIZATION_TYPE_URL) {
+    const key = String(stakeAuthType ?? "");
+    return REVOKE_MSG_TYPE_URL_BY_STAKE_AUTH_TYPE[key] ?? authorizationTypeUrl;
+  }
+
+  return (
+    REVOKE_MSG_TYPE_URL_BY_AUTHORIZATION[authorizationTypeUrl] ??
+    authorizationTypeUrl
+  );
+}

--- a/packages/account-management/src/grants/revoke.ts
+++ b/packages/account-management/src/grants/revoke.ts
@@ -35,6 +35,13 @@ const REVOKE_MSG_TYPE_URL_BY_AUTHORIZATION: Record<string, string> = {
  * target. Keyed by both the enum name and its numeric proto value so either
  * representation from the chain/API resolves correctly.
  */
+// NOTE: the `AUTHORIZATION_TYPE_*` keys below are plain object *string keys*,
+// not references to an imported enum — an unquoted identifier in an object
+// literal is just a string key. (They read unquoted because the repo's
+// prettier `quoteProps: "as-needed"` strips quotes from identifier-shaped
+// keys; the numeric keys stay quoted because they must.) Both the enum name
+// and its numeric proto value are keyed so either representation the
+// chain/API returns resolves.
 const REVOKE_MSG_TYPE_URL_BY_STAKE_AUTH_TYPE: Record<string, string> = {
   AUTHORIZATION_TYPE_DELEGATE: "/cosmos.staking.v1beta1.MsgDelegate",
   "1": "/cosmos.staking.v1beta1.MsgDelegate",

--- a/packages/account-management/src/grants/strategies/__tests__/treasury-composite-strategy.test.ts
+++ b/packages/account-management/src/grants/strategies/__tests__/treasury-composite-strategy.test.ts
@@ -305,6 +305,43 @@ describe("CompositeTreasuryStrategy", () => {
       expect(result).toEqual(mockTreasuryConfigs.basic);
     });
 
+    // When DaoDao rejects an unindexed-placeholder response (admin is null),
+    // the racing composite must let DirectQuery win rather than surfacing the
+    // placeholder — otherwise the connect screen degrades to "Read access
+    // only" for a treasury that DirectQuery could resolve.
+    it("should fall back to DirectQuery when DaoDao rejects admin-null", async () => {
+      const directQueryConfig = {
+        ...mockTreasuryConfigs.basic,
+        metadata: '{"name": "DirectQuery"}',
+      };
+      const daodao: TreasuryStrategy = {
+        fetchTreasuryConfig: vi.fn(async () => {
+          throw new Error(
+            "DaoDao treasury strategy failed: DaoDao indexer has no data for this treasury (admin is null)",
+          );
+        }),
+        constructor: { name: "DaoDaoTreasuryStrategy" } as any,
+      };
+      const directQuery = createDelayedMockStrategy(
+        "DirectQueryTreasuryStrategy",
+        "success",
+        10,
+        directQueryConfig,
+      );
+      const composite = new CompositeTreasuryStrategy([daodao, directQuery], {
+        racing: true,
+      });
+
+      const result = await composite.fetchTreasuryConfig(
+        "xion1treasury",
+        mockClient,
+      );
+
+      expect(result).toEqual(directQueryConfig);
+      expect(daodao.fetchTreasuryConfig).toHaveBeenCalledOnce();
+      expect(directQuery.fetchTreasuryConfig).toHaveBeenCalledOnce();
+    });
+
     it("should throw when all strategies fail", async () => {
       const strategy1 = createMockStrategy("Strategy1", "error");
       const strategy2 = createMockStrategy("Strategy2", "error");

--- a/packages/account-management/src/grants/strategies/__tests__/treasury-daodao-strategy.test.ts
+++ b/packages/account-management/src/grants/strategies/__tests__/treasury-daodao-strategy.test.ts
@@ -37,6 +37,12 @@ describe("DaoDaoTreasuryStrategy", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reassign a fresh fetch mock each test. `vi.clearAllMocks()` clears call
+    // history but NOT the `mockResolvedValueOnce` queue, so a test whose fetch
+    // is never reached (e.g. the URL-safety case passes `{}` and throws in
+    // `getChainId` first) would otherwise leak its queued response into the
+    // next test — an off-by-one the admin-null cases are sensitive to.
+    global.fetch = vi.fn();
     strategy = new DaoDaoTreasuryStrategy({
       indexerUrl: "https://daodao.example.com",
     });
@@ -47,6 +53,7 @@ describe("DaoDaoTreasuryStrategy", () => {
       (global.fetch as any).mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          admin: "xion1adminaddress",
           grantConfigs: {
             [mockGrantTypeUrls.genericAuthorization]: {
               authorization: {
@@ -78,6 +85,7 @@ describe("DaoDaoTreasuryStrategy", () => {
       (global.fetch as any).mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          admin: "xion1adminaddress",
           grantConfigs: {},
           params: mockTreasuryParams.basic,
         }),
@@ -135,6 +143,7 @@ describe("DaoDaoTreasuryStrategy", () => {
       (global.fetch as any).mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          admin: "xion1adminaddress",
           grantConfigs: {
             [mockGrantTypeUrls.genericAuthorization]: {
               authorization: {
@@ -167,6 +176,7 @@ describe("DaoDaoTreasuryStrategy", () => {
       (global.fetch as any).mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          admin: "xion1adminaddress",
           grantConfigs: {},
           params: {
             redirect_url: "javascript:alert(1)",
@@ -190,6 +200,7 @@ describe("DaoDaoTreasuryStrategy", () => {
       (global.fetch as any).mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          admin: "xion1adminaddress",
           grantConfigs: {},
           params: mockTreasuryParams.basic,
         }),
@@ -211,6 +222,7 @@ describe("DaoDaoTreasuryStrategy", () => {
       (global.fetch as any).mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          admin: "xion1adminaddress",
           grantConfigs: {},
           params: mockTreasuryParams.basic,
         }),
@@ -221,6 +233,90 @@ describe("DaoDaoTreasuryStrategy", () => {
       });
 
       expect(result?.grantConfigs).toEqual([]);
+    });
+
+    // admin-null guard: the indexer returns an all-defaults placeholder
+    // (`{ admin: null, grantConfigs: {}, … }`) for any contract it hasn't
+    // indexed, instead of a 404. Without the guard that placeholder passes
+    // the structural checks as a "successful" empty treasury, and in a
+    // racing composite it can beat DirectQuery and silently degrade the user
+    // to "Read access only". The strategy must reject it instead.
+    it("should reject the unindexed placeholder when admin is null", async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          admin: null,
+          grantConfigs: {},
+          feeConfig: null,
+          params: {},
+        }),
+      });
+
+      await expect(
+        strategy.fetchTreasuryConfig("xion1treasury", {
+          getChainId: vi.fn().mockResolvedValue("xion-testnet-2"),
+        }),
+      ).rejects.toThrow(/admin is null/i);
+    });
+
+    it("should reject when admin is a blank/whitespace string", async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          admin: "   ",
+          grantConfigs: {},
+          params: {},
+        }),
+      });
+
+      await expect(
+        strategy.fetchTreasuryConfig("xion1treasury", {
+          getChainId: vi.fn().mockResolvedValue("xion-testnet-2"),
+        }),
+      ).rejects.toThrow(/admin is null/i);
+    });
+
+    it("should reject when admin is missing entirely", async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          grantConfigs: {},
+          params: {},
+        }),
+      });
+
+      await expect(
+        strategy.fetchTreasuryConfig("xion1treasury", {
+          getChainId: vi.fn().mockResolvedValue("xion-testnet-2"),
+        }),
+      ).rejects.toThrow(/admin is null/i);
+    });
+
+    it("should delegate to the normal transform when admin is present", async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          admin: "xion1adminaddress",
+          grantConfigs: {
+            [mockGrantTypeUrls.genericAuthorization]: {
+              authorization: {
+                type_url: mockGrantTypeUrls.genericAuthorization,
+                value: "base64encodedvalue",
+              },
+              description: "Execute contracts",
+              optional: false,
+            },
+          },
+          params: mockTreasuryParams.basic,
+        }),
+      });
+
+      const result = await strategy.fetchTreasuryConfig("xion1treasury", {
+        getChainId: vi.fn().mockResolvedValue("xion-testnet-2"),
+      });
+
+      expect(result?.grantConfigs).toHaveLength(1);
+      expect(result?.params.redirect_url).toBe("https://dashboard.burnt.com");
     });
   });
 });

--- a/packages/account-management/src/grants/strategies/treasury-daodao-strategy.ts
+++ b/packages/account-management/src/grants/strategies/treasury-daodao-strategy.ts
@@ -146,6 +146,40 @@ export class DaoDaoTreasuryStrategy implements TreasuryStrategy {
     // TODO: Consider adding end-to-end typing with zod or io-ts for full runtime validation
     const response = data as Record<string, unknown>;
 
+    // Reject the indexer's all-defaults placeholder. For a contract it hasn't
+    // indexed, the DaoDao indexer returns `{ admin: null, grantConfigs: {}, … }`
+    // rather than a 404 — which would otherwise pass the structural checks
+    // below as a "successful" empty treasury.
+    //
+    // We treat a null/absent/blank admin as "no usable data". Strictly,
+    // admin=null *could* be a legitimate response, but in practice it's an
+    // indication of an empty treasury — typically something the indexer was
+    // asked about but never actually indexed. We also reject an empty/blank
+    // string: a placeholder admin of `""` is no more usable than `null`, and a
+    // real treasury always has a bech32 admin. Because we can't tell a
+    // placeholder apart from a real empty result, we don't surface it as one: a
+    // partial/placeholder config would silently degrade the caller (e.g. to
+    // "Read access only") instead of letting the authoritative on-chain query
+    // answer.
+    //
+    // Throwing here (rather than returning empty) makes the strategy *reject*,
+    // which is the routing signal we want:
+    //  - In a `CompositeTreasuryStrategy` with `DirectQueryTreasuryStrategy`
+    //    (the default fallback) — both sequential and racing modes treat the
+    //    rejection as "use the other strategy", so the authoritative on-chain
+    //    query wins instead of this placeholder silently degrading the caller
+    //    to "Read access only".
+    //  - Used standalone (no chain fallback) — the rejection surfaces as an
+    //    error, which is correct: we can't be sure the placeholder is valid.
+    if (
+      response.admin == null ||
+      (typeof response.admin === "string" && response.admin.trim() === "")
+    ) {
+      throw new Error(
+        "DaoDao indexer has no data for this treasury (admin is null)",
+      );
+    }
+
     // Validate the top-level structure
     if (!response.grantConfigs || typeof response.grantConfigs !== "object") {
       throw new Error("Invalid indexer response: missing grantConfigs");

--- a/packages/account-management/src/grants/strategies/treasury-daodao-strategy.ts
+++ b/packages/account-management/src/grants/strategies/treasury-daodao-strategy.ts
@@ -176,7 +176,7 @@ export class DaoDaoTreasuryStrategy implements TreasuryStrategy {
       (typeof response.admin === "string" && response.admin.trim() === "")
     ) {
       throw new Error(
-        "DaoDao indexer has no data for this treasury (admin is null)",
+        "DaoDao indexer has no data for this treasury (admin is null, blank, or missing)",
       );
     }
 

--- a/packages/signers/src/crypto/__tests__/derive-cosmos-bech32.test.ts
+++ b/packages/signers/src/crypto/__tests__/derive-cosmos-bech32.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { deriveCosmosBech32 } from "../address";
+
+// Valid compressed secp256k1 public key (33 bytes), base64-encoded, with its
+// known derived addresses for "xion" and "cosmos" prefixes.
+const VALID_PUBKEY_B64 = "AlMM9kMvmfX+wfePigniQkpdmaSLNtCnoW8WXbAOLSfC";
+const EXPECTED_XION = "xion1cg2r54yq37qyd3gdjv3t2c0c5yt844akwx50c8";
+const EXPECTED_COSMOS = "cosmos1cg2r54yq37qyd3gdjv3t2c0c5yt844akv0wdwv";
+
+describe("deriveCosmosBech32", () => {
+  describe("valid derivations", () => {
+    it("derives the expected xion address from a raw secp256k1 pubkey", () => {
+      expect(deriveCosmosBech32(VALID_PUBKEY_B64, "xion")).toBe(EXPECTED_XION);
+    });
+
+    it("derives a different bech32 address per prefix", () => {
+      expect(deriveCosmosBech32(VALID_PUBKEY_B64, "cosmos")).toBe(
+        EXPECTED_COSMOS,
+      );
+    });
+
+    it("is deterministic for the same inputs", () => {
+      expect(deriveCosmosBech32(VALID_PUBKEY_B64, "xion")).toBe(
+        deriveCosmosBech32(VALID_PUBKEY_B64, "xion"),
+      );
+    });
+  });
+
+  describe("invalid inputs return null", () => {
+    it("returns null for an empty pubkey", () => {
+      expect(deriveCosmosBech32("", "xion")).toBeNull();
+    });
+
+    it("returns null for an empty prefix", () => {
+      expect(deriveCosmosBech32(VALID_PUBKEY_B64, "")).toBeNull();
+    });
+
+    it("returns null for a non-base64 pubkey", () => {
+      expect(deriveCosmosBech32("not!base64!!", "xion")).toBeNull();
+    });
+
+    it("returns null for a wrong-length key (CosmJS requires 33-byte compressed)", () => {
+      // Base64 of a 4-byte buffer — decodes fine but is not a valid pubkey.
+      // rawSecp256k1PubkeyToRawAddress only accepts the 33-byte compressed
+      // form and throws on anything else, so derivation returns null.
+      const tooShort = Buffer.from([1, 2, 3, 4]).toString("base64");
+      expect(deriveCosmosBech32(tooShort, "xion")).toBeNull();
+    });
+
+    it("does not throw on malformed input", () => {
+      expect(() => deriveCosmosBech32("???", "xion")).not.toThrow();
+    });
+  });
+});

--- a/packages/signers/src/crypto/address.ts
+++ b/packages/signers/src/crypto/address.ts
@@ -4,6 +4,8 @@
  */
 
 import { instantiate2Address } from "@cosmjs/cosmwasm-stargate";
+import { rawSecp256k1PubkeyToRawAddress } from "@cosmjs/amino";
+import { fromBase64, toBech32 } from "@cosmjs/encoding";
 import { validateAndDecodeHex, validateAddressPrefix } from "./hex-validation";
 
 /**
@@ -44,4 +46,34 @@ export function calculateSmartAccountAddress(config: {
     saltBytes,
     config.prefix,
   );
+}
+
+/**
+ * Derive a bech32 address from a raw secp256k1 public key
+ *
+ * Hashes the raw compressed public key into a Cosmos account address
+ * (`sha256` → `ripemd160`, via CosmJS's `rawSecp256k1PubkeyToRawAddress`) and
+ * encodes it with the given bech32 prefix. This is the standard "pubkey → cosmos
+ * address" derivation, useful for showing the underlying signer address of a
+ * Secp256K1 authenticator.
+ *
+ * Returns `null` rather than throwing for any invalid input (empty/missing
+ * arguments, non-base64 pubkey, wrong key length, etc.) so callers can use it
+ * directly in rendering paths without try/catch.
+ *
+ * @param rawPubkeyBase64 - Base64-encoded raw secp256k1 public key (compressed, 33 bytes)
+ * @param prefix - Bech32 address prefix (e.g., "xion", "cosmos")
+ * @returns The derived bech32 address, or `null` if derivation fails
+ */
+export function deriveCosmosBech32(
+  rawPubkeyBase64: string,
+  prefix: string,
+): string | null {
+  if (!rawPubkeyBase64 || !prefix) return null;
+  try {
+    const rawAddr = rawSecp256k1PubkeyToRawAddress(fromBase64(rawPubkeyBase64));
+    return toBech32(prefix, rawAddr);
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
Simulate additions to help guard against issues (like no signature in contracT) and additions to guard against empty indexer responses.

Responses to 2 bugs over past few weeks.