### PR TITLE
fix(account-management): urlsMatch compares full URL origin (incl. port)

### DIFF
--- a/.changeset/brave-otters-rescue.md
+++ b/.changeset/brave-otters-rescue.md
@@ -1,0 +1,5 @@
+---
+"@burnt-labs/account-management": patch
+---
+
+`urlsMatch` now compares the full URL origin (protocol + host + port) instead of only protocol + host. URLs that differ only by port (e.g. `https://example.com:443` vs `https://example.com:8443`) are no longer treated as matching, and unparseable inputs compare as non-matching.

--- a/packages/account-management/src/utils/__tests__/url.test.ts
+++ b/packages/account-management/src/utils/__tests__/url.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { urlsMatch } from "../url";
+
+describe("urlsMatch", () => {
+  it("matches same-origin URLs with different paths", () => {
+    expect(
+      urlsMatch("https://example.com/path1", "https://example.com/path2"),
+    ).toBe(true);
+  });
+
+  it("matches same-origin URLs that differ only in path", () => {
+    expect(urlsMatch("https://example.com/a", "https://example.com/b")).toBe(
+      true,
+    );
+  });
+
+  it("does not match when only the port differs", () => {
+    expect(urlsMatch("https://example.com", "https://example.com:8443")).toBe(
+      false,
+    );
+  });
+
+  it("does not match an explicit default port against a different port", () => {
+    // 443 (the https default) vs 8443.
+    expect(
+      urlsMatch("https://example.com:443", "https://example.com:8443"),
+    ).toBe(false);
+  });
+
+  it("does not match different protocols (http vs https)", () => {
+    expect(urlsMatch("https://example.com", "http://example.com")).toBe(false);
+  });
+
+  it("does not match different hosts", () => {
+    expect(urlsMatch("https://example.com", "https://other.com")).toBe(false);
+  });
+
+  it("matches identical URLs", () => {
+    expect(urlsMatch("https://example.com", "https://example.com")).toBe(true);
+  });
+
+  it("ignores trailing slash, path, query, and hash differences", () => {
+    expect(urlsMatch("https://example.com", "https://example.com/")).toBe(true);
+    expect(
+      urlsMatch("https://example.com/", "https://example.com/deep/path"),
+    ).toBe(true);
+    expect(
+      urlsMatch("https://example.com/a?x=1", "https://example.com/b?y=2"),
+    ).toBe(true);
+    expect(
+      urlsMatch("https://example.com/a#one", "https://example.com/b#two"),
+    ).toBe(true);
+  });
+
+  it("treats an explicit default port the same as an implicit one", () => {
+    expect(
+      urlsMatch("https://example.com:443/x", "https://example.com/y"),
+    ).toBe(true);
+  });
+
+  it("returns false when one input is undefined", () => {
+    expect(urlsMatch(undefined, "https://example.com")).toBe(false);
+    expect(urlsMatch("https://example.com", undefined)).toBe(false);
+  });
+
+  it("returns false when one input is an empty string", () => {
+    expect(urlsMatch("", "https://example.com")).toBe(false);
+    expect(urlsMatch("https://example.com", "")).toBe(false);
+  });
+
+  it("returns false when both inputs are undefined", () => {
+    expect(urlsMatch(undefined, undefined)).toBe(false);
+  });
+
+  it("returns false when both inputs are empty strings", () => {
+    expect(urlsMatch("", "")).toBe(false);
+  });
+
+  it("returns false for an unparseable string against a valid URL", () => {
+    expect(urlsMatch("not a url", "https://example.com")).toBe(false);
+  });
+
+  it("returns false when both inputs are unparseable", () => {
+    expect(urlsMatch("not a url", "also not a url")).toBe(false);
+    expect(urlsMatch("garbage", "garbage")).toBe(false);
+  });
+});

--- a/packages/account-management/src/utils/url.ts
+++ b/packages/account-management/src/utils/url.ts
@@ -128,22 +128,39 @@ export function isUrlSafe(url: string | undefined): boolean {
 }
 
 /**
- * Compare two URLs by their domain and protocol
- * Useful for validating redirect URLs match expected domains
+ * Reduce a URL to its origin — `protocol` + `host` + `port`.
  *
- * @param urlA - First URL to compare
- * @param urlB - Second URL to compare
- * @returns true if URLs have matching domain and protocol
+ * Returns `null` for values that don't parse, so two unparseable inputs never
+ * compare equal. The port is part of the origin: `https://host` and
+ * `https://host:8443` are different origins.
+ */
+function toOrigin(url: string | undefined): string | null {
+  try {
+    return new URL(url || "").origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare two URLs by their origin (`protocol` + `host` + `port`).
+ *
+ *  - port-sensitive       — `https://x` ≠ `https://x:8443`
+ *  - protocol-sensitive   — `https://x` ≠ `http://x`
+ *  - path/query/hash-insensitive — same-origin URLs compare equal regardless of
+ *    path. (For a path-sensitive comparison, compare
+ *    `toOrigin(x) + new URL(x).pathname` instead.)
+ *  - unparseable input never matches.
  *
  * @example
- * ```typescript
- * urlsMatch("https://example.com/path1", "https://example.com/path2") // true
- * urlsMatch("https://example.com", "http://example.com") // false (different protocol)
- * ```
+ * urlsMatch("https://example.com/a", "https://example.com/b") // true  (same origin)
+ * urlsMatch("https://example.com",   "https://example.com:8443") // false (port differs)
+ * urlsMatch("https://example.com",   "http://example.com") // false (protocol differs)
  */
 export function urlsMatch(
   urlA: string | undefined,
   urlB: string | undefined,
 ): boolean {
-  return getDomainAndProtocol(urlA) === getDomainAndProtocol(urlB);
+  const a = toOrigin(urlA);
+  return a !== null && a === toOrigin(urlB);
 }


### PR DESCRIPTION
## Summary

`urlsMatch(a, b)` reduced each URL to `protocol + "//" + hostname` (via `getDomainAndProtocol`), which **drops the port**. Two consequences:

- URLs that differ only by port compared as equal — `https://example.com` matched `https://example.com:8443` (and `:443` vs `:8443`).
- Any value that fails to parse reduced to `""`, so two unparseable inputs compared as equal.

## Change

- `urlsMatch` now compares by **URL origin** (`protocol` + `host` + `port`) via `new URL(x).origin`.
- A private `toOrigin` helper returns `null` for unparseable input, so non-URLs never compare equal.
- Matching stays path/query/hash-insensitive (origin-level); the docblock notes the one-line change for a path-sensitive comparison if it's ever needed.
- `getDomainAndProtocol` and `isUrlSafe` are unchanged.

## Tests

New `packages/account-management/src/utils/__tests__/url.test.ts` (vitest): port / protocol / host differences, path/query/hash insensitivity, default-port normalization, and undefined / empty / unparseable inputs.

Validation: `build`, `test:unit` (724 passed, incl. the new file), and `lint` all green. Changeset included (`patch`).
